### PR TITLE
Security page proposal

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -471,6 +471,11 @@ sectionPagesMenu = 'main'
   url = "https://blog.qgis.org/"
   weight = 180
 
+[[menu.main]]
+  parent = "Support"
+  name = "Security"
+  url = "/resources/support/security"
+  weight = 190
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]

--- a/content/resources/support.md
+++ b/content/resources/support.md
@@ -56,8 +56,7 @@ Good luck with the organization of your local user group. Please inform the inte
 
 ## Security Vulnerability Reporting
 
-If you believe you have found a security issue, please refer to the [security page]({{< ref "resources/support/security" >}}) for information on how to report it.
-
+If you believe you have found a security issue, such as vulnerabilities in QGIS or its dependencies, please refer to the [security page]({{< ref "resources/support/security" >}}) for detailed information on how to report it responsibly.
 
 {{< content-end >}}
 

--- a/content/resources/support.md
+++ b/content/resources/support.md
@@ -54,4 +54,11 @@ The website should be used to publish any material in relation to the informatio
 
 Good luck with the organization of your local user group. Please inform the international QGIS team by registering at the QGIS community list and reporting about your progress. Please do not hesitate to ask questions regarding the establishment and maintenance of your local user group.
 
+## Security Vulnerability Reporting
+
+If you believe you have found a security issue, please refer to the [security page]({{< ref "resources/support/security" >}}) for information on how to report it.
+
+
 {{< content-end >}}
+
+

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -63,7 +63,7 @@ If you believe you have found a security issue, such as vulnerabilities in QGIS 
 
 QGIS offers Python bindings so that you can extend it by writing plugins, geoprocessing models, actions, project macros, or even rewrite a full application based on PyQGIS. 
 
-In a desktop environment, any scripting language has full access to the user land resources. If you execute blindly external code, it can do a lot of harm. 
+In a desktop environment, any scripting language has full access to the user resources and execute arbitrary code with the permissions of the user. If you execute blindly external code, it can do a lot of harm. 
 
 QGIS main plugins repository is permissively open, but approval of plugins is still reviewed manually. We do not take advance QA assessment of plugin code. However we forbid to ship compiled code, so you know what you get and are free to audit the code. 
 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -19,7 +19,7 @@ For these reasons, this is how QGIS project acts to respond to vulnerabilities a
 ### What is a vulnerability in QGIS ? 
 
 QGIS is a broad project with several different components, relying on a large base of external dependencies (GDAL, PROJ, Python libraries, Qt, etc..). 
-Security issues in QGIS can arise in various scenarios, including, but not limited to, vulnerabilities in its dependencies (e.g., GDAL, Proj, Qt), issues within QGIS code itself, or through the misuse of its Python bindings. Here are the main categories:
+Security issues in QGIS can arise in various scenarios, including, but not limited to, vulnerabilities in its dependencies, issues within QGIS code itself, or through the misuse of its Python bindings. Here are the main categories:
 
 #### Vulnerabilies of underlying libraries 
 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -33,7 +33,7 @@ OSGEO4W provides update scripts that can run silently, allowing you to upgrade o
 
 On **[Ubuntu / Debian](/resources/installation-guide/#debianubuntu)**, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / PROJ / GRASS).
 For Python and Qt libraries, which rely on your operating system, please ensure they are updated regularly using your system's update manager. For Ubuntu/Debian, this typically involves using commands like `sudo apt-get update` and `sudo apt-get upgrade`.
-Other packages are maintained by the community, such as Conda, FlatPak, etc.. Any issue should be raised to the dedicated maintainers.  
+Other packages are maintained by the community, such as Conda, FlatPak, etc. Any issue should be raised to the dedicated maintainers.  
 
 #### False positives
 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -16,7 +16,7 @@ The QGIS community takes security as a serious matter. We are aware that QGIS is
 For these reasons, this is how QGIS project acts to respond to vulnerabilities and security matters. 
 
 
-### What is a vulnerability in QGIS ? 
+### What is a vulnerability in QGIS?
 
 QGIS is a broad project with several different components, relying on a large base of external dependencies (GDAL, PROJ, Python libraries, Qt, etc..). 
 Security issues in QGIS can arise in various scenarios, including, but not limited to, vulnerabilities in its dependencies, issues within QGIS code itself, or through the misuse of its Python bindings. Here are the main categories:

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -18,7 +18,7 @@ For these reasons, this is how QGIS project acts to respond to vulnerabilities a
 
 ### What is a vulnerability in QGIS ? 
 
-QGIS is a broad project with several different components, relying on a large base of external dependencies (GDAL, Proj, python libraries, Qt, etc..). 
+QGIS is a broad project with several different components, relying on a large base of external dependencies (GDAL, PROJ, Python libraries, Qt, etc..). 
 Security issues in QGIS can arise in various scenarios, including, but not limited to, vulnerabilities in its dependencies (e.g., GDAL, Proj, Qt), issues within QGIS code itself, or through the misuse of its Python bindings. Here are the main categories:
 
 #### Vulnerabilies of underlying libraries 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -30,11 +30,12 @@ Security issues fall in the following cases :
 If you run a code scanner, most of the vulnerabilities are not concerning QGIS, but its dependencies. 
 The version of the dependencies shipped with your QGIS depends on the OS and packaging system you use. 
 
-**On Windows**, we use OSGEO4W project to distribute a complete environnement, and we fully maintain it.
+**On Windows**, QGIS.org use OSGEO4W project to distribute a complete environnement, and we fully maintain it.
+Other packages are maintained by the community, such as Conda, FlatPak, etc.. Any issue should be raised to the dedicated maintainers.  
 
 This installer is updated every month with various fixes and upgrades. If the latest version doesn't include a version fixing the vulnerability, please raise an issue on the dedicated [OSGEO4W bug tracker](https://trac.osgeo.org/osgeo4w/).
 
-On **Ubuntu / Debian**, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / Proj / GRASS).
+On **[Ubuntu / Debian](/resources/installation-guide/#debianubuntu)**, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / Proj / GRASS).
 But python and Qt libraries rely on your OS and you have to use your update manager here. 
 
 #### False positives

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -61,7 +61,7 @@ If you believe you have found a security issue, such as vulnerabilities in QGIS 
 
 #### Running python QGIS 
 
-QGIS offers python bindings so that you can extend it by writing plugins, geoprocessing models, actions, project macros, or even rewrite a full application based on pyQGIS. 
+QGIS offers Python bindings so that you can extend it by writing plugins, geoprocessing models, actions, project macros, or even rewrite a full application based on PyQGIS. 
 
 In a desktop environment, any scripting language has full access to the user land resources. If you execute blindly external code, it can do a lot of harm. 
 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -20,12 +20,10 @@ The QGIS community takes security as a serious matter. We are aware that QGIS is
 For these reasons, this is how QGIS project acts to respond to vulnerabilities and security matters. 
 
 
-Our main landing page for security issues is on our [Github's repositoy](https://github.com/qgis/QGIS/security).
-
-
 ### What is a vulnerability in QGIS ? 
 
 QGIS is a broad project with several different components, relying on a large base of external dependencies (GDAL, Proj, python libraries, Qt, etc..). 
+Security issues fall in the following cases : 
 
 #### Vulnerabilies of underlying libraries 
 
@@ -36,42 +34,45 @@ The version of the dependencies shipped with your QGIS depends on the OS and pac
 
 This installer is updated every month with various fixes and upgrades. If the latest version doesn't include a version fixing the vulnerability, please raise an issue on the dedicated [OSGEO4W bug tracker](https://trac.osgeo.org/osgeo4w/).
 
-On Ubuntu / Debian, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / Proj / GRASS).
+On **Ubuntu / Debian**, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / Proj / GRASS).
 But python and Qt libraries rely on your OS and you have to use your update manager here. 
 
 #### False positives
 
-We collect a lot of library upgrade due to false positive. For instance, PostgreSQL client library embedded in QGIS trigger vulnerabilities of the **server part**, which is not shipped with QGIS installer.  
+We collect a lot of demands due to false positive detection by code scanners.
 
-Before blindly pushing your code scanner alerts, keep calm and don't panic. Read the CVE report, go to the upstream project CVE description and please verify this really concerns. 
-Please also raise this to your code scanner vendor so that they update their catalog accordingly. We can't do anything from our side, but are flooded by those reports. This way you preserve the available bandwith of the contributors for the real issues. 
+For instance, PostgreSQL client library (psql, libpq) embedded in QGIS, trigger vulnerabilities of the **server part**, which is **not shipped with QGIS installer**.  
+
+Before blindly pushing your code scanner alerts, keep calm and don't panic. 
+Read the CVE report, go to the upstream project CVE description and please verify this really concerns. 
+Please also raise this to your code scanner vendor so that they update their catalog accordingly.
+We can't do anything from our side if an upstream CVE has been badly classified, but we end up in being flooded by those reports. This way you preserve the available bandwidth of the contributors for the real issues. 
 
 #### Vulnerabilities of QGIS itself
 
-Those are extremely rare but can occur as in any software. 
+Those are extremely rare but can occur as in any software.
+
+QGIS server is a more critical part than QGIS desktop, since it is exposed to the web on public servers. It has been assessed against SQL injections and various known leaks by big corporations since years now. 
 
 If you found an issue: 
  - check you are using the latest version of QGIS, and have a glance at the nighlty version for potential ongoing changes
+ - check if your issue concerns QGIS desktop or QGIS server part
  - please check our [Bug tracker](https://github.com/qgis/QGIS/issues) for an already existing and potential fix
  - then only, raise a private disclosure to the security teams [our GitHub security page](https://github.com/qgis/QGIS/security).
-
-QGIS server is a more critical part than QGIS desktop, since it is exposed to the web on public servers. It has been assessed against SQL injections and various known leaks by big corporations since years now. 
-Please be specific in your disclosure if QGIS server is concerned or not. 
-
 
 
 #### Running python QGIS 
 
-QGIS offers python bindings so that you can extend it by writting plugins, geoprocessing models, actions, project macros, or even rewrite a full application based on pyQGIS. 
+QGIS offers python bindings so that you can extend it by writing plugins, geoprocessing models, actions, project macros, or even rewrite a full application based on pyQGIS. 
 
-In a desktop environnement, any scripting language has full access to the userland ressources. If you execute blindly external code, it can do a lot of harm. 
+In a desktop environment, any scripting language has full access to the user land resources. If you execute blindly external code, it can do a lot of harm. 
 
 QGIS main plugins repository is permissively open, but approval of plugins is still reviewed manually. We do not take advance QA assessment of plugin code. However we forbid to ship compiled code, so you know what you get and are free to audit the code. 
 
 
-If your are working in a sensitive environnement, we advise you to :
+If your are working in a sensitive environment, we advise you to :
 
-- Audit carefully the plugins you allow to your users, in a sandboxed environnement
+- Audit carefully the plugins you allow to your users, in a sandboxed environment
 - Deploy your own plugin repository in which you control which plugin are available
 - Take benefit of the advanced customization possibilities of QGIS to constraint settings around connexions, authentication etc..
 - Don't focus only on code breaches, but also on user behavior regarding credentials and the risk of leak in project files if users insist on using basic authentication.  
@@ -82,11 +83,13 @@ If your are working in a sensitive environnement, we advise you to :
 Currently, QGIS project is **not** a CVE Numbering Authority (CNA), so we don't affect CVE identifiers. 
 
 
-### Security Process
+### Security Process and workflow
 
 Disclosures are discussed in a private dedicated repository.
 
 Fixes are shipped as soon as possible - regarding the criticity of the issue - in point releases. 
+
+If you want to secure your QGIS enterprise deployment, please ensure to be able to quickly deploy fixes on your machines. OSGEO4W has update scripts that can run silently and upgrade only the libraries you need without redownloading the full package.
 
 
 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -37,7 +37,7 @@ Other packages are maintained by the community, such as Conda, FlatPak, etc. Any
 
 #### False positives
 
-Receiving red flags from code scanner alerts can be alarming, but many of the current alerts are false positive, so keep calm and don't panic. 
+Receiving red flags from code scanner alerts can be alarming, but many of the current alerts are false positive, so keep calm and don't panic.
 
 For example, a common false positive might involve the PostgreSQL client library (libpq) being flagged for server-side vulnerabilities, which do not apply to QGIS's use case.
 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -18,7 +18,7 @@ For these reasons, this is how QGIS project acts to respond to vulnerabilities a
 
 ### What is a vulnerability in QGIS?
 
-QGIS is a broad project with several different components, relying on a large base of external dependencies (GDAL, PROJ, Python libraries, Qt, etc..). 
+QGIS is a broad project with several different components, relying on a large base of external dependencies (GDAL, PROJ, Python libraries, Qt, etc.). 
 Security issues in QGIS can arise in various scenarios, including, but not limited to, vulnerabilities in its dependencies, issues within QGIS code itself, or through the misuse of its Python bindings. Here are the main categories:
 
 #### Vulnerabilies of underlying libraries 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -31,7 +31,7 @@ The version of the dependencies shipped with your QGIS depends on the OS and pac
 OSGEO4W provides update scripts that can run silently, allowing you to upgrade only the necessary libraries without the need to redownload the entire package. For more information on setting up these scripts for your deployment, refer to the [OSGEO4W documentation](https://trac.osgeo.org/osgeo4w/).
 
 
-On **[Ubuntu / Debian](/resources/installation-guide/#debianubuntu)**, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / Proj / GRASS).
+On **[Ubuntu / Debian](/resources/installation-guide/#debianubuntu)**, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / PROJ / GRASS).
 For Python and Qt libraries, which rely on your operating system, please ensure they are updated regularly using your system's update manager. For Ubuntu/Debian, this typically involves using commands like `sudo apt-get update` and `sudo apt-get upgrade`.
 Other packages are maintained by the community, such as Conda, FlatPak, etc.. Any issue should be raised to the dedicated maintainers.  
 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -65,7 +65,7 @@ QGIS offers Python bindings so that you can extend it by writing plugins, geopro
 
 In a desktop environment, any scripting language has full access to the user resources and execute arbitrary code with the permissions of the user. If you execute blindly external code, it can do a lot of harm. 
 
-QGIS main plugins repository is permissively open, but approval of plugins is still reviewed manually. We do not take advance QA assessment of plugin code. However we forbid to ship compiled code, so you know what you get and are free to audit the code. 
+QGIS main plugins repository is permissively open, but approval of plugins is still reviewed manually. We do not take advance QA assessment of plugin code. However, we forbid to ship compiled code, so you know what you get and are free to audit the code. 
 
 
 If your are working in a sensitive environment, we advise you to :

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -9,10 +9,6 @@ sidebar: true
 
 {{< content-start  >}}
 
-
-
- 
-
 ## Security information
 
 The QGIS community takes security as a serious matter. We are aware that QGIS is deployed in sensitive environnements. 
@@ -23,7 +19,7 @@ For these reasons, this is how QGIS project acts to respond to vulnerabilities a
 ### What is a vulnerability in QGIS ? 
 
 QGIS is a broad project with several different components, relying on a large base of external dependencies (GDAL, Proj, python libraries, Qt, etc..). 
-Security issues fall in the following cases : 
+Security issues in QGIS can arise in various scenarios, including, but not limited to, vulnerabilities in its dependencies (e.g., GDAL, Proj, Qt), issues within QGIS code itself, or through the misuse of its Python bindings. Here are the main categories:
 
 #### Vulnerabilies of underlying libraries 
 
@@ -31,36 +27,38 @@ If you run a code scanner, most of the vulnerabilities are not concerning QGIS, 
 The version of the dependencies shipped with your QGIS depends on the OS and packaging system you use. 
 
 **On Windows**, QGIS.org use OSGEO4W project to distribute a complete environnement, and we fully maintain it.
-Other packages are maintained by the community, such as Conda, FlatPak, etc.. Any issue should be raised to the dedicated maintainers.  
 
-This installer is updated every month with various fixes and upgrades. If the latest version doesn't include a version fixing the vulnerability, please raise an issue on the dedicated [OSGEO4W bug tracker](https://trac.osgeo.org/osgeo4w/).
+OSGEO4W provides update scripts that can run silently, allowing you to upgrade only the necessary libraries without the need to redownload the entire package. For more information on setting up these scripts for your deployment, refer to the [OSGEO4W documentation](https://trac.osgeo.org/osgeo4w/).
+
 
 On **[Ubuntu / Debian](/resources/installation-guide/#debianubuntu)**, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / Proj / GRASS).
-But python and Qt libraries rely on your OS and you have to use your update manager here. 
+For Python and Qt libraries, which rely on your operating system, please ensure they are updated regularly using your system's update manager. For Ubuntu/Debian, this typically involves using commands like `sudo apt-get update` and `sudo apt-get upgrade`.
+Other packages are maintained by the community, such as Conda, FlatPak, etc.. Any issue should be raised to the dedicated maintainers.  
 
 #### False positives
 
-We collect a lot of demands due to false positive detection by code scanners.
+Receiving red flags from code scanner alerts can be alarming, but many of the current alerts are false positive, so keep calm and don't panic. 
 
-For instance, PostgreSQL client library (psql, libpq) embedded in QGIS, trigger vulnerabilities of the **server part**, which is **not shipped with QGIS installer**.  
+For example, a common false positive might involve the PostgreSQL client library (libpq) being flagged for server-side vulnerabilities, which do not apply to QGIS's use case.
 
-Before blindly pushing your code scanner alerts, keep calm and don't panic. 
 Read the CVE report, go to the upstream project CVE description and please verify this really concerns. 
-Please also raise this to your code scanner vendor so that they update their catalog accordingly.
-We can't do anything from our side if an upstream CVE has been badly classified, but we end up in being flooded by those reports. This way you preserve the available bandwidth of the contributors for the real issues. 
 
-#### Vulnerabilities of QGIS itself
+Please also communicate these findings to your code scanner vendor for catalog updates, to let a chance this stops in the future. 
+
+There is not much QGIS contributors can do when the classification of dependencies is not accurate in the CVE database.
+
+### Vulnerabilities of QGIS itself
 
 Those are extremely rare but can occur as in any software.
 
 QGIS server is a more critical part than QGIS desktop, since it is exposed to the web on public servers. It has been assessed against SQL injections and various known leaks by big corporations since years now. 
 
-If you found an issue: 
- - check you are using the latest version of QGIS, and have a glance at the nighlty version for potential ongoing changes
- - check if your issue concerns QGIS desktop or QGIS server part
- - please check our [Bug tracker](https://github.com/qgis/QGIS/issues) for an already existing and potential fix
+If you believe you have found a security issue, such as vulnerabilities in QGIS or its dependencies, please refer to the [security page]({{< ref "resources/support/security" >}}) for detailed information on how to report it responsibly. Before this, please do the following
+ - Check you are using the latest version of QGIS, and have a glance at the nighlty version for potential ongoing changes (fixes or regressions)
+ - Check if your issue concerns QGIS desktop or QGIS server part
+ - Please check our [Bug tracker](https://github.com/qgis/QGIS/issues) for an already existing and potential fix
  - then only, raise a private disclosure to the security teams [our GitHub security page](https://github.com/qgis/QGIS/security).
-
+ - then only, raise a private disclosure to the security teams via [our GitHub security page](https://github.com/qgis/QGIS/security). Please avoid publicly disclosing the vulnerability until it has been resolved to prevent potential exploitation.
 
 #### Running python QGIS 
 
@@ -90,8 +88,9 @@ Disclosures are discussed in a private dedicated repository.
 
 Fixes are shipped as soon as possible - regarding the criticity of the issue - in point releases. 
 
-If you want to secure your QGIS enterprise deployment, please ensure to be able to quickly deploy fixes on your machines. OSGEO4W has update scripts that can run silently and upgrade only the libraries you need without redownloading the full package.
+If you want to secure your QGIS enterprise deployment, please ensure to be able to quickly deploy fixes on your machines. 
 
+OSGEO4W provides update scripts that can run silently, allowing you to upgrade only the necessary libraries without the need to redownload the entire package. For more information on setting up these scripts for your deployment, refer to the [OSGEO4W documentation](https://trac.osgeo.org/osgeo4w/).
 
 
 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -1,0 +1,94 @@
+
+---
+type: "page"
+title: "Security"
+subtitle: ""
+draft: false
+sidebar: true
+---
+
+{{< content-start  >}}
+
+
+
+ 
+
+## Security information
+
+The QGIS community takes security as a serious matter. We are aware that QGIS is deployed in sensitive environnements. 
+
+For these reasons, this is how QGIS project acts to respond to vulnerabilities and security matters. 
+
+
+Our main landing page for security issues is on our [Github's repositoy](https://github.com/qgis/QGIS/security).
+
+
+### What is a vulnerability in QGIS ? 
+
+QGIS is a broad project with several different components, relying on a large base of external dependencies (GDAL, Proj, python libraries, Qt, etc..). 
+
+#### Vulnerabilies of underlying libraries 
+
+If you run a code scanner, most of the vulnerabilities are not concerning QGIS, but its dependencies. 
+The version of the dependencies shipped with your QGIS depends on the OS and packaging system you use. 
+
+**On Windows**, we use OSGEO4W project to distribute a complete environnement, and we fully maintain it.
+
+This installer is updated every month with various fixes and upgrades. If the latest version doesn't include a version fixing the vulnerability, please raise an issue on the dedicated [OSGEO4W bug tracker](https://trac.osgeo.org/osgeo4w/).
+
+On Ubuntu / Debian, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / Proj / GRASS).
+But python and Qt libraries rely on your OS and you have to use your update manager here. 
+
+#### False positives
+
+We collect a lot of library upgrade due to false positive. For instance, PostgreSQL client library embedded in QGIS trigger vulnerabilities of the **server part**, which is not shipped with QGIS installer.  
+
+Before blindly pushing your code scanner alerts, keep calm and don't panic. Read the CVE report, go to the upstream project CVE description and please verify this really concerns. 
+Please also raise this to your code scanner vendor so that they update their catalog accordingly. We can't do anything from our side, but are flooded by those reports. This way you preserve the available bandwith of the contributors for the real issues. 
+
+#### Vulnerabilities of QGIS itself
+
+Those are extremely rare but can occur as in any software. 
+
+If you found an issue: 
+ - check you are using the latest version of QGIS, and have a glance at the nighlty version for potential ongoing changes
+ - please check our [Bug tracker](https://github.com/qgis/QGIS/issues) for an already existing and potential fix
+ - then only, raise a private disclosure to the security teams [our GitHub security page](https://github.com/qgis/QGIS/security).
+
+QGIS server is a more critical part than QGIS desktop, since it is exposed to the web on public servers. It has been assessed against SQL injections and various known leaks by big corporations since years now. 
+Please be specific in your disclosure if QGIS server is concerned or not. 
+
+
+
+#### Running python QGIS 
+
+QGIS offers python bindings so that you can extend it by writting plugins, geoprocessing models, actions, project macros, or even rewrite a full application based on pyQGIS. 
+
+In a desktop environnement, any scripting language has full access to the userland ressources. If you execute blindly external code, it can do a lot of harm. 
+
+QGIS main plugins repository is permissively open, but approval of plugins is still reviewed manually. We do not take advance QA assessment of plugin code. However we forbid to ship compiled code, so you know what you get and are free to audit the code. 
+
+
+If your are working in a sensitive environnement, we advise you to :
+
+- Audit carefully the plugins you allow to your users, in a sandboxed environnement
+- Deploy your own plugin repository in which you control which plugin are available
+- Take benefit of the advanced customization possibilities of QGIS to constraint settings around connexions, authentication etc..
+- Don't focus only on code breaches, but also on user behavior regarding credentials and the risk of leak in project files if users insist on using basic authentication.  
+ 
+
+### Do we affect Common Vulnerabilities and Exposures (CVE) ?  
+
+Currently, QGIS project is **not** a CVE Numbering Authority (CNA), so we don't affect CVE identifiers. 
+
+
+### Security Process
+
+Disclosures are discussed in a private dedicated repository.
+
+Fixes are shipped as soon as possible - regarding the criticity of the issue - in point releases. 
+
+
+
+
+{{< content-end >}}

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -26,7 +26,7 @@ Security issues in QGIS can arise in various scenarios, including, but not limit
 If you run a code scanner, most of the vulnerabilities are not concerning QGIS, but its dependencies. 
 The version of the dependencies shipped with your QGIS depends on the OS and packaging system you use. 
 
-**On Windows**, QGIS.org use OSGEO4W project to distribute a complete environment, and we fully maintain it.
+**On Windows**, QGIS.org uses the OSGEO4W project to distribute a complete environment, and we fully maintain it.
 
 OSGEO4W provides update scripts that can run silently, allowing you to upgrade only the necessary libraries without the need to redownload the entire package. For more information on setting up these scripts for your deployment, refer to the [OSGEO4W documentation](https://trac.osgeo.org/osgeo4w/).
 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -7,7 +7,7 @@ draft: false
 sidebar: true
 ---
 
-{{< content-start  >}}
+{{< content-start >}}
 
 ## Security information
 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -11,7 +11,7 @@ sidebar: true
 
 ## Security information
 
-The QGIS community takes security as a serious matter. We are aware that QGIS is deployed in sensitive environnements. 
+The QGIS community takes security as a serious matter. We are aware that QGIS is deployed in sensitive environments. 
 
 For these reasons, this is how QGIS project acts to respond to vulnerabilities and security matters. 
 
@@ -26,7 +26,7 @@ Security issues in QGIS can arise in various scenarios, including, but not limit
 If you run a code scanner, most of the vulnerabilities are not concerning QGIS, but its dependencies. 
 The version of the dependencies shipped with your QGIS depends on the OS and packaging system you use. 
 
-**On Windows**, QGIS.org use OSGEO4W project to distribute a complete environnement, and we fully maintain it.
+**On Windows**, QGIS.org use OSGEO4W project to distribute a complete environment, and we fully maintain it.
 
 OSGEO4W provides update scripts that can run silently, allowing you to upgrade only the necessary libraries without the need to redownload the entire package. For more information on setting up these scripts for your deployment, refer to the [OSGEO4W documentation](https://trac.osgeo.org/osgeo4w/).
 
@@ -57,7 +57,6 @@ If you believe you have found a security issue, such as vulnerabilities in QGIS 
  - Check you are using the latest version of QGIS, and have a glance at the nighlty version for potential ongoing changes (fixes or regressions)
  - Check if your issue concerns QGIS desktop or QGIS server part
  - Please check our [Bug tracker](https://github.com/qgis/QGIS/issues) for an already existing and potential fix
- - then only, raise a private disclosure to the security teams [our GitHub security page](https://github.com/qgis/QGIS/security).
  - then only, raise a private disclosure to the security teams via [our GitHub security page](https://github.com/qgis/QGIS/security). Please avoid publicly disclosing the vulnerability until it has been resolved to prevent potential exploitation.
 
 #### Running python QGIS 
@@ -73,7 +72,7 @@ If your are working in a sensitive environment, we advise you to :
 
 - Audit carefully the plugins you allow to your users, in a sandboxed environment
 - Deploy your own plugin repository in which you control which plugin are available
-- Take benefit of the advanced customization possibilities of QGIS to constraint settings around connexions, authentication etc..
+- Take benefit of the advanced customization possibilities of QGIS to constraint settings around connections, authentication etc..
 - Don't focus only on code breaches, but also on user behavior regarding credentials and the risk of leak in project files if users insist on using basic authentication.  
  
 

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -85,7 +85,7 @@ Currently, QGIS project is **not** a CVE Numbering Authority (CNA), so we don't 
 
 Disclosures are discussed in a private dedicated repository.
 
-Fixes are shipped as soon as possible - regarding the criticity of the issue - in point releases. 
+Fixes are shipped as soon as possible - regarding the criticality of the issue - in point releases. 
 
 If you want to secure your QGIS enterprise deployment, please ensure to be able to quickly deploy fixes on your machines. 
 

--- a/static/img/logosign.svg
+++ b/static/img/logosign.svg
@@ -7,8 +7,8 @@
    x="0px"
    y="0px"
    width="336"
-   height="328"
-   viewBox="0 0 336 328"
+   height="336"
+   viewBox="0 0 134.4 134.4"
    enable-background="new 0 0 128 128"
    xml:space="preserve"
    sodipodi:docname="logosign.svg"
@@ -17,8 +17,8 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"><defs
-   id="defs953" /><sodipodi:namedview
-   id="namedview951"
+   id="defs1165" /><sodipodi:namedview
+   id="namedview1163"
    pagecolor="#ffffff"
    bordercolor="#666666"
    borderopacity="1.0"
@@ -26,9 +26,9 @@
    inkscape:pageopacity="0.0"
    inkscape:pagecheckerboard="0"
    showgrid="false"
-   inkscape:zoom="1.296875"
-   inkscape:cx="65.542169"
-   inkscape:cy="104.09639"
+   inkscape:zoom="0.6484375"
+   inkscape:cx="26.216867"
+   inkscape:cy="-209.73494"
    inkscape:window-width="3440"
    inkscape:window-height="1384"
    inkscape:window-x="0"
@@ -38,8 +38,8 @@
 <polygon
    fill="#ee7913"
    points="71.697,54.625 52.613,54.625 52.613,72.746 68.613,88.548 68.613,69.625 86.891,69.625 "
-   id="polygon930"
-   transform="matrix(2.5887065,0,0,2.5887065,3.3493976,-3.3017225)" />
+   id="polygon1142"
+   transform="translate(3.9590361,3.4722892)" />
 <linearGradient
    id="SVGID_1_"
    gradientUnits="userSpaceOnUse"
@@ -51,23 +51,23 @@
 	<stop
    offset="0"
    style="stop-color:#589632"
-   id="stop932" />
+   id="stop1144" />
 	<stop
    offset="1"
    style="stop-color:#93B023"
-   id="stop934" />
+   id="stop1146" />
 </linearGradient>
 <polygon
    fill="url(#SVGID_1_)"
    points="76.613,77.625 76.613,96.033 107.143,126.625 126.613,126.625 126.613,109.057 94.488,77.625 "
-   id="polygon937"
+   id="polygon1149"
    style="fill:url(#SVGID_1_)"
-   transform="matrix(2.5887065,0,0,2.5887065,3.3493976,-3.3017225)" />
+   transform="translate(3.9590361,3.4722892)" />
 <polygon
    fill="#f0e64a"
    points="86.891,69.625 68.613,69.625 68.613,88.548 76.613,96.033 76.613,77.625 94.488,77.625 "
-   id="polygon939"
-   transform="matrix(2.5887065,0,0,2.5887065,3.3493976,-3.3017225)" />
+   id="polygon1151"
+   transform="translate(3.9590361,3.4722892)" />
 <linearGradient
    id="SVGID_2_"
    gradientUnits="userSpaceOnUse"
@@ -75,26 +75,26 @@
    y1="-221.14549"
    x2="363.59229"
    y2="-98.226997"
-   gradientTransform="matrix(2.5887066,0,0,-2.5887066,-774.60741,-242.89868)">
+   gradientTransform="matrix(1,0,0,-1,-296.56046,-89.082411)">
 	<stop
    offset="0"
    style="stop-color:#589632"
-   id="stop941" />
+   id="stop1153" />
 	<stop
    offset="1"
    style="stop-color:#93B023"
-   id="stop943" />
+   id="stop1155" />
 </linearGradient>
 <path
    fill="url(#SVGID_2_)"
-   d="m 181.77082,259.58659 c -3.01585,0.62647 -4.57943,0.40643 -12.1281,0.40643 -54.01595,0 -99.95513,-44.41703 -99.95513,-102.01057 0,-57.59353 45.43439,-101.029441 99.95513,-101.029441 54.52076,0 97.93854,43.438491 97.93854,101.029441 0,9.36853 -1.16751,18.37723 -3.3239,26.91737 l 49.99569,49.99052 c 12.88916,-22.58906 20.1013,-48.84631 20.1013,-77.29101 C 334.35435,68.835171 263.51957,2.3727225 168.63572,2.3727225 74.184173,2.3701345 3.3493976,68.395091 3.3493976,157.59673 c 0,89.63397 70.8347754,156.97399 165.2837324,156.97399 24.37785,0 41.59792,-3.80281 59.64898,-9.73613 z"
-   id="path946"
-   style="fill:url(#SVGID_2_);stroke-width:2.58871" />
+   d="m 72.882036,105.02429 c -1.165,0.242 -1.769,0.157 -4.685,0.157 -20.866,0 -38.612,-17.158001 -38.612,-39.406001 0,-22.248 17.551,-39.027 38.612,-39.027 21.061,0 37.833004,16.78 37.833004,39.027 0,3.619 -0.451,7.099 -1.284,10.398 l 19.313,19.311 c 4.979,-8.726 7.765,-18.869 7.765,-29.857 0,-34.289 -27.363,-59.9629998 -64.016004,-59.9629998 -36.486,-10e-4 -63.8489999,25.5039998 -63.8489999,59.9619998 0,34.625001 27.3629999,60.638001 63.8479999,60.638001 9.417,0 16.069,-1.469 23.042,-3.761 z"
+   id="path1158"
+   style="fill:url(#SVGID_2_)" />
 <polygon
    opacity="0.15"
    fill="#ffffff"
    enable-background="new    "
    points="126.613,109.057 126.613,126.625 53.083,54.625 71.697,54.625 "
-   id="polygon948"
-   transform="matrix(2.5887065,0,0,2.5887065,3.3493976,-3.3017225)" />
+   id="polygon1160"
+   transform="translate(3.9590361,3.4722892)" />
 </svg>

--- a/static/img/logosign.svg
+++ b/static/img/logosign.svg
@@ -7,8 +7,8 @@
    x="0px"
    y="0px"
    width="336"
-   height="336"
-   viewBox="0 0 134.4 134.4"
+   height="328"
+   viewBox="0 0 336 328"
    enable-background="new 0 0 128 128"
    xml:space="preserve"
    sodipodi:docname="logosign.svg"
@@ -17,8 +17,8 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"><defs
-   id="defs1165" /><sodipodi:namedview
-   id="namedview1163"
+   id="defs953" /><sodipodi:namedview
+   id="namedview951"
    pagecolor="#ffffff"
    bordercolor="#666666"
    borderopacity="1.0"
@@ -26,9 +26,9 @@
    inkscape:pageopacity="0.0"
    inkscape:pagecheckerboard="0"
    showgrid="false"
-   inkscape:zoom="0.6484375"
-   inkscape:cx="26.216867"
-   inkscape:cy="-209.73494"
+   inkscape:zoom="1.296875"
+   inkscape:cx="65.542169"
+   inkscape:cy="104.09639"
    inkscape:window-width="3440"
    inkscape:window-height="1384"
    inkscape:window-x="0"
@@ -38,8 +38,8 @@
 <polygon
    fill="#ee7913"
    points="71.697,54.625 52.613,54.625 52.613,72.746 68.613,88.548 68.613,69.625 86.891,69.625 "
-   id="polygon1142"
-   transform="translate(3.9590361,3.4722892)" />
+   id="polygon930"
+   transform="matrix(2.5887065,0,0,2.5887065,3.3493976,-3.3017225)" />
 <linearGradient
    id="SVGID_1_"
    gradientUnits="userSpaceOnUse"
@@ -51,23 +51,23 @@
 	<stop
    offset="0"
    style="stop-color:#589632"
-   id="stop1144" />
+   id="stop932" />
 	<stop
    offset="1"
    style="stop-color:#93B023"
-   id="stop1146" />
+   id="stop934" />
 </linearGradient>
 <polygon
    fill="url(#SVGID_1_)"
    points="76.613,77.625 76.613,96.033 107.143,126.625 126.613,126.625 126.613,109.057 94.488,77.625 "
-   id="polygon1149"
+   id="polygon937"
    style="fill:url(#SVGID_1_)"
-   transform="translate(3.9590361,3.4722892)" />
+   transform="matrix(2.5887065,0,0,2.5887065,3.3493976,-3.3017225)" />
 <polygon
    fill="#f0e64a"
    points="86.891,69.625 68.613,69.625 68.613,88.548 76.613,96.033 76.613,77.625 94.488,77.625 "
-   id="polygon1151"
-   transform="translate(3.9590361,3.4722892)" />
+   id="polygon939"
+   transform="matrix(2.5887065,0,0,2.5887065,3.3493976,-3.3017225)" />
 <linearGradient
    id="SVGID_2_"
    gradientUnits="userSpaceOnUse"
@@ -75,26 +75,26 @@
    y1="-221.14549"
    x2="363.59229"
    y2="-98.226997"
-   gradientTransform="matrix(1,0,0,-1,-296.56046,-89.082411)">
+   gradientTransform="matrix(2.5887066,0,0,-2.5887066,-774.60741,-242.89868)">
 	<stop
    offset="0"
    style="stop-color:#589632"
-   id="stop1153" />
+   id="stop941" />
 	<stop
    offset="1"
    style="stop-color:#93B023"
-   id="stop1155" />
+   id="stop943" />
 </linearGradient>
 <path
    fill="url(#SVGID_2_)"
-   d="m 72.882036,105.02429 c -1.165,0.242 -1.769,0.157 -4.685,0.157 -20.866,0 -38.612,-17.158001 -38.612,-39.406001 0,-22.248 17.551,-39.027 38.612,-39.027 21.061,0 37.833004,16.78 37.833004,39.027 0,3.619 -0.451,7.099 -1.284,10.398 l 19.313,19.311 c 4.979,-8.726 7.765,-18.869 7.765,-29.857 0,-34.289 -27.363,-59.9629998 -64.016004,-59.9629998 -36.486,-10e-4 -63.8489999,25.5039998 -63.8489999,59.9619998 0,34.625001 27.3629999,60.638001 63.8479999,60.638001 9.417,0 16.069,-1.469 23.042,-3.761 z"
-   id="path1158"
-   style="fill:url(#SVGID_2_)" />
+   d="m 181.77082,259.58659 c -3.01585,0.62647 -4.57943,0.40643 -12.1281,0.40643 -54.01595,0 -99.95513,-44.41703 -99.95513,-102.01057 0,-57.59353 45.43439,-101.029441 99.95513,-101.029441 54.52076,0 97.93854,43.438491 97.93854,101.029441 0,9.36853 -1.16751,18.37723 -3.3239,26.91737 l 49.99569,49.99052 c 12.88916,-22.58906 20.1013,-48.84631 20.1013,-77.29101 C 334.35435,68.835171 263.51957,2.3727225 168.63572,2.3727225 74.184173,2.3701345 3.3493976,68.395091 3.3493976,157.59673 c 0,89.63397 70.8347754,156.97399 165.2837324,156.97399 24.37785,0 41.59792,-3.80281 59.64898,-9.73613 z"
+   id="path946"
+   style="fill:url(#SVGID_2_);stroke-width:2.58871" />
 <polygon
    opacity="0.15"
    fill="#ffffff"
    enable-background="new    "
    points="126.613,109.057 126.613,126.625 53.083,54.625 71.697,54.625 "
-   id="polygon1160"
-   transform="translate(3.9590361,3.4722892)" />
+   id="polygon948"
+   transform="matrix(2.5887065,0,0,2.5887065,3.3493976,-3.3017225)" />
 </svg>


### PR DESCRIPTION
@sleeping-h here is a first draft for a security page 


@jef-n @pblottiere @lbartoletti @elpaso  I'd be pleased to here from you about this proposal. The idea is to clarify things for users, and reduce traffic for false positives. 
I think we miss a section to adress all those requests to fill forms for various regulations. I will also open a discussion about activating the dedicated services of github so that we rely less on our seecurity mail, but that's for the future

cc @mbernasocchi @timlinux  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Introduced a "Security Vulnerability Reporting" section to guide users on how to report security issues.
    - Launched a comprehensive "Security" page detailing how security concerns are managed, including handling vulnerabilities, securing deployments, and the security workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->