### PR TITLE
Make the download link on top in the installation guide

### DIFF
--- a/content/resources/installation-guide/index.md
+++ b/content/resources/installation-guide/index.md
@@ -16,7 +16,7 @@ QGIS is available on Windows, macOS, Linux, Android and iOS.
 
 We recommend installing the packages of the released software.
 
-See also [The main installers page]({{< ref "download" >}}).
+See also [the main installers page]({{< ref "download" >}}).
 
 To evaluate the upcoming release and to allow non-developers to support development we also provide testing packages (note the [warning](#warning)).
 

--- a/playwright/ci-test/tests/fixtures/installation-guide-page.ts
+++ b/playwright/ci-test/tests/fixtures/installation-guide-page.ts
@@ -170,7 +170,7 @@ export class InstallationGuidePage {
             .getByRole("cell", { name: "Package" })
             .first();
         this.mainInstallersPageLink = this.page.getByRole("link", {
-            name: "The main installers page",
+            name: "the main installers page",
         });
         this.osgeo4WInstallerLink = this.page.getByRole("link", {
             name: "OSGeo4W Installer",


### PR DESCRIPTION
Please find below a screenshot of the change:

![image](https://github.com/qgis/QGIS-Hugo/assets/43842786/e2254d72-fb49-41c3-adea-aaa9c243417a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
    - Updated the installation guide with a reference link to the main installers page.
    - Enhanced the description of the weekly snapshots for the qgis-dev package.
    - Improved consistency by updating a link name in the `InstallationGuidePage` class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->