### PR TITLE
Replace project to product in playwright e2e test

### DIFF
--- a/playwright/ci-test/tests/01-home-page.spec.ts
+++ b/playwright/ci-test/tests/01-home-page.spec.ts
@@ -32,8 +32,8 @@ test.describe("Home page", () => {
 
     test("Header", async ({ header }) => {
         await expect(header.logoLink).toBeVisible();
-        await expect(header.projectLink).toBeVisible();
-        await header.projectLink.hover();
+        await expect(header.producttLink).toBeVisible();
+        await header.producttLink.hover();
         await expect(header.overviewLink).toBeVisible();
         await expect(header.caseStudiesLink).toBeVisible();
         await expect(header.pluginsLink).toBeVisible();

--- a/playwright/ci-test/tests/02-download-page.spec.ts
+++ b/playwright/ci-test/tests/02-download-page.spec.ts
@@ -33,7 +33,7 @@ test("Download page", async ({ homePage, sidebar, downloadPage }) => {
     await expect(downloadPage.otherMethodsLink).toBeVisible();
     await expect(downloadPage.currencyInput).toBeVisible();
     await expect(downloadPage.skipDownloadButton).toBeVisible();
-    await expect(sidebar.projectLink).toBeVisible();
+    await expect(sidebar.producttLink).toBeVisible();
     await expect(sidebar.overviewLink).toBeVisible();
     await expect(sidebar.caseStudiesLink).toBeVisible();
     await expect(sidebar.pluginsLink).toBeVisible();

--- a/playwright/ci-test/tests/03-product-page.spec.ts
+++ b/playwright/ci-test/tests/03-product-page.spec.ts
@@ -27,7 +27,7 @@ const test = base.extend<ProductPageFixtures>({
 test("Product page", async ({ homePage, sidebar, productPage }) => {
     await homePage.goto();
     await homePage.downloadLink.click();
-    await sidebar.projectLink.click();
+    await sidebar.producttLink.click();
     await expect(productPage.fosQGISLink).toBeVisible();
     await expect(productPage.qgisOverview).toBeVisible();
     await expect(productPage.contentTab1Img).toBeVisible();

--- a/playwright/ci-test/tests/fixtures/header.ts
+++ b/playwright/ci-test/tests/fixtures/header.ts
@@ -4,7 +4,7 @@ export class Header {
     public readonly banner: Locator;
     public readonly mainNavigation: Locator;
     public readonly logoLink: Locator;
-    public readonly projectLink: Locator;
+    public readonly producttLink: Locator;
     public readonly overviewLink: Locator;
     public readonly caseStudiesLink: Locator;
     public readonly pluginsLink: Locator;
@@ -33,7 +33,7 @@ export class Header {
         this.banner = this.page.getByRole("banner");
         this.mainNavigation = this.page.getByLabel("main navigation");
         this.logoLink = this.mainNavigation.getByRole("link").first();
-        this.projectLink = this.mainNavigation.getByText("Project", {
+        this.producttLink = this.mainNavigation.getByText("Product", {
             exact: true,
         });
         this.overviewLink = this.mainNavigation.getByRole("link", {

--- a/playwright/ci-test/tests/fixtures/sidebar.ts
+++ b/playwright/ci-test/tests/fixtures/sidebar.ts
@@ -2,7 +2,7 @@ import type { Page, Locator } from "@playwright/test";
 
 export class Sidebar {
     public readonly sidebar: Locator;
-    public readonly projectLink: Locator;
+    public readonly producttLink: Locator;
     public readonly overviewLink: Locator;
     public readonly caseStudiesLink: Locator;
     public readonly pluginsLink: Locator;
@@ -30,7 +30,7 @@ export class Sidebar {
 
     constructor(public readonly page: Page) {
         this.sidebar = this.page.locator("#sidebar");
-        this.projectLink = this.sidebar.getByRole("link", {
+        this.producttLink = this.sidebar.getByRole("link", {
             name: "Product",
         });
         this.overviewLink = this.sidebar.getByRole("link", {


### PR DESCRIPTION
This is a proposed fix for the playwright e2e test after we changed `Project` to `Product` in the navigation bar (#221 ). This should be applied before #237 and #239 to fix the failed workflow. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated element references from `projectLink` to `producttLink` across multiple test files and fixtures to ensure consistency and correct interaction within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->