### PR TITLE
Remove super old links to inexistent QGIS for android

### DIFF
--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/mobile-downloads.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/mobile-downloads.html
@@ -19,5 +19,3 @@
 	<a href="https://github.com/roam-qgis/Roam/releases"><img alt="Get it for Windows" src="{{ absURL "img/app_download_windows.png" }}"></a>
 	<a href="https://github.com/roam-qgis/Roam/releases"><img alt="Get it on GitHub" src="{{ absURL "img/app_download_gh.png" }}"></a>
 </div>
-<h5>QGIS for Android</h5>
-<p>An old and deprecated not touch optimised release of QGIS for Android can be found in <a href="{{ absURL "resources/installation-guide#android" }}">All downloads</a></p>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the mobile downloads section to remove outdated QGIS for Android release information and highlight third-party touch-optimized apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->