### PR TITLE
fix membership naming

### DIFF
--- a/themes/hugo-bulma-blocks-theme/layouts/partials/funders-simple.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/partials/funders-simple.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="pb-2">
             <h2>
-                QGIS supporters
+                QGIS sustaining members
             </h2>
         </div>
         <div class="supporters-grid large-grid">
@@ -37,11 +37,11 @@
                             
                                 {{ if eq .Params.level "Flagship" }}
                                     <p class=" partner-title">
-                                        Golden partner
+                                        Flagship member
                                     </p>
                                 {{ else }}
                                     <p class="partner-title">
-                                        Silver partner
+                                        Large member
                                     </p>
                                 {{ end }}
                                 <br>


### PR DESCRIPTION
replaced silver and gold partner on the mainpage with the correct naming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated terminology for QGIS supporters to "QGIS sustaining members."
  - Changed partner titles from "Golden partner" to "Flagship member" and "Silver partner" to "Large member."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->