### PR TITLE
Add links to metabase analytics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -453,13 +453,13 @@ sectionPagesMenu = 'main'
 
 [[menu.main]]
   parent = "Resources"
-  name = "QGIS Dashboard"
+  name = "QGIS Metrics"
   url = "https://analytics.qgis.org"
   weight = 180
 
 [[menu.main]]
   parent = "Resources"
-  name = "Plugins Dashboard"
+  name = "Plugins Metrics"
   url = "https://plugins.qgis.org/metabase/public/dashboard/7ecd345f-7321-423d-9844-71e526a454a9"
   weight = 190
 

--- a/config.toml
+++ b/config.toml
@@ -453,9 +453,21 @@ sectionPagesMenu = 'main'
 
 [[menu.main]]
   parent = "Resources"
+  name = "QGIS Dashboard"
+  url = "https://analytics.qgis.org"
+  weight = 180
+
+[[menu.main]]
+  parent = "Resources"
+  name = "Plugins Dashboard"
+  url = "https://plugins.qgis.org/metabase/public/dashboard/7ecd345f-7321-423d-9844-71e526a454a9"
+  weight = 190
+
+[[menu.main]]
+  parent = "Resources"
   name = "Blog"
   url = "https://blog.qgis.org/"
-  weight = 180
+  weight = 200
 
 [[menu.main]]
   parent = "Support"

--- a/playwright/ci-test/tests/01-home-page.spec.ts
+++ b/playwright/ci-test/tests/01-home-page.spec.ts
@@ -116,6 +116,8 @@ test.describe("Home page", () => {
         await expect(footer.reportsLink).toBeVisible();
         await expect(footer.booksLink).toBeVisible();
         await expect(footer.supportLink).toBeVisible();
+        await expect(footer.qgisDashboardLink).toBeVisible();
+        await expect(footer.pluginsDashboardLink).toBeVisible();
         await expect(footer.blogLink).toBeVisible();
         await expect(footer.donateLink).toBeVisible();
         await expect(footer.membershipList).toBeVisible();

--- a/playwright/ci-test/tests/fixtures/footer.ts
+++ b/playwright/ci-test/tests/fixtures/footer.ts
@@ -58,7 +58,7 @@ export class Footer {
         this.caseStudiesLink = this.banner.getByRole("link", {
             name: "Case studies",
         });
-        this.pluginsLink = this.banner.getByRole("link", { name: "Plugins" });
+        this.pluginsLink = this.banner.getByRole("link", { name: "Plugins", exact: true });
         this.visualChangelogsLink = this.banner.getByRole("link", {
             name: "Visual Changelogs",
         });
@@ -92,11 +92,11 @@ export class Footer {
         this.reportsLink = this.banner.getByRole("link", { name: "Reports" });
         this.booksLink = this.banner.getByRole("link", { name: "Books" });
         this.supportLink = this.banner.getByRole("link", { name: "Support" });
-        this.blogLink = this.banner.getByRole("link", {
+        this.qgisDashboardLink = this.banner.getByRole("link", {
             name: "QGIS Dashboard",
             exact: true,
         });
-        this.blogLink = this.banner.getByRole("link", {
+        this.pluginsDashboardLink = this.banner.getByRole("link", {
             name: "Plugins Dashboard",
             exact: true,
         });

--- a/playwright/ci-test/tests/fixtures/footer.ts
+++ b/playwright/ci-test/tests/fixtures/footer.ts
@@ -25,6 +25,8 @@ export class Footer {
     public readonly reportsLink: Locator;
     public readonly booksLink: Locator;
     public readonly supportLink: Locator;
+    public readonly qgisDashboardLink: Locator;
+    public readonly pluginsDashboardLink: Locator;
     public readonly blogLink: Locator;
     public readonly donateLink: Locator;
     public readonly membershipList: Locator;
@@ -90,6 +92,14 @@ export class Footer {
         this.reportsLink = this.banner.getByRole("link", { name: "Reports" });
         this.booksLink = this.banner.getByRole("link", { name: "Books" });
         this.supportLink = this.banner.getByRole("link", { name: "Support" });
+        this.blogLink = this.banner.getByRole("link", {
+            name: "QGIS Dashboard",
+            exact: true,
+        });
+        this.blogLink = this.banner.getByRole("link", {
+            name: "Plugins Dashboard",
+            exact: true,
+        });
         this.blogLink = this.banner.getByRole("link", {
             name: "Blog",
             exact: true,

--- a/playwright/ci-test/tests/fixtures/footer.ts
+++ b/playwright/ci-test/tests/fixtures/footer.ts
@@ -93,11 +93,11 @@ export class Footer {
         this.booksLink = this.banner.getByRole("link", { name: "Books" });
         this.supportLink = this.banner.getByRole("link", { name: "Support" });
         this.qgisDashboardLink = this.banner.getByRole("link", {
-            name: "QGIS Dashboard",
+            name: "QGIS Metrics",
             exact: true,
         });
         this.pluginsDashboardLink = this.banner.getByRole("link", {
-            name: "Plugins Dashboard",
+            name: "Plugins Metrics",
             exact: true,
         });
         this.blogLink = this.banner.getByRole("link", {

--- a/playwright/ci-test/tests/fixtures/sidebar.ts
+++ b/playwright/ci-test/tests/fixtures/sidebar.ts
@@ -41,6 +41,7 @@ export class Sidebar {
         });
         this.pluginsLink = this.sidebar.getByRole("link", {
             name: "Plugins",
+            exact: true
         });
         this.visualChangelogsLink = this.sidebar.getByRole("link", {
             name: "Visual Changelogs",


### PR DESCRIPTION
Fix for #375 

This PR proposes to add the links to the dashboard for QGIS and for the QGIS Plugins web portal:

- QGIS Dashboard: https://analytics.qgis.org
- Plugins Dashboard: https://plugins.qgis.org/metabase/public/dashboard/7ecd345f-7321-423d-9844-71e526a454a9

Just so you know, this PR depends on https://github.com/qgis/qgis-uni-navigation/pull/9 which adds the links to the menu in the navigation bar.

![image](https://github.com/user-attachments/assets/25595da3-a3d6-4c00-bd19-396046e1db7c)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added "QGIS Metrics" and "Plugins Metrics" links to the Resources menu for enhanced navigation.
	
- **Bug Fixes**
	- Improved the initialization of footer links for more reliable access and functionality.

- **Tests**
	- Expanded test coverage for the home page to verify the visibility of the new dashboard links in the footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->