### PR TITLE
Show current point release on roadmap

### DIFF
--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
@@ -1,7 +1,7 @@
 <div class="container">
     <div class="roadmap  mb-4">
         {{ with index .Site.Data.conf }}
-            <div class="right-ribbon"><span class="stable">Current: {{ .ltrversion }}</span></div>
+            <div class="right-ribbon"><span class="stable">Current: {{ .ltrrelease }}</span></div>
         {{ end }}
     <h3 class="title">Long Term Release (LTR)</h3>
     <ul class="steps is-balanced">
@@ -89,7 +89,7 @@
 
     <div class="roadmap  mb-4">
     {{ with index .Site.Data.conf }}
-        <div class="right-ribbon"><span class="latest">Current: {{ .version }}</span></div>
+        <div class="right-ribbon"><span class="latest">Current: {{ .release }}</span></div>
     {{ end }}
     <h3 class="title">Latest Release</h3>
     <ul class="steps is-balanced">


### PR DESCRIPTION
Ther roadmap gives all information regarding release versions but it is not immediately evident which are the current point release.
![image](https://github.com/user-attachments/assets/fe110e57-17bb-4620-951f-5323fa8e57b4)

This PR adds the point release number to the ribbon.
![image](https://github.com/user-attachments/assets/9669cf9a-e805-4b88-bd31-7f51b4ea42b6)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the display of Long Term Release and Latest Release version information for improved clarity.
	- Enhanced naming conventions for version variables to better reflect the data being presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->