### PR TITLE
Add sustaining member links in visual changelog page

### DIFF
--- a/content/project/visual-changelogs.md
+++ b/content/project/visual-changelogs.md
@@ -10,6 +10,12 @@ sidebar: true
 
 ## Visual Changelogs
 
+QGIS is a community effort, and we would like to extend a big thank you to the developers, documenters, testers, and the many folks out there who volunteer their time and effort (or fund people to do so) to make these releases possible. From the QGIS community, we hope you enjoy this release! If you wish to donate time, money, or otherwise contribute towards making QGIS more awesome, please wander along to [QGIS.ORG](https://qgis.org) and lend a hand!
+
+QGIS is supported by donors and sustaining members. A current list of donors who have made financial contributions large or small to the project can be seen on our [list of donors](/funding/donate/donors/). If you would like to become an official project sustaining member, please visit our [sustaining member page](/funding/membership/) for more details. Sponsoring QGIS helps us to fund our regular developer meetings, maintain project infrastructure, and fund bug-fixing efforts. A complete list of current sponsors is provided below - our very thank you to all of our sponsors!
+
+QGIS is free software and you are under no obligation to pay anything to use it - in fact, we want to encourage people far and wide to use it regardless of their financial or social status - we believe that empowering people with spatial decision-making tools will result in a better society for all of humanity.
+
 Below, you will find the Visual Changelogs since version 2.0.
 
 {{< visualchangelogs >}}


### PR DESCRIPTION
Proposed fix for #383 

Please see also https://github.com/qgis/qgis-uni-navigation/pull/10 for the menu bar

- Add the common text and sustaining members/donor links from each visual changelog to the main page

![image](https://github.com/user-attachments/assets/c6dd5803-bc48-4f4f-833d-442ce63185ab)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the "Visual Changelogs" section with new paragraphs emphasizing community support, contributions, and the importance of donations to sustain the QGIS project.
- **Documentation**
  - Updated content to provide greater context about the collaborative nature and funding efforts of the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->