### PR TITLE
Add an select menu to choose language for documentation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -472,6 +472,87 @@ sectionPagesMenu = 'main'
   url = "/resources/support/security"
   weight = 190
 
+# Languages for translated docs
+[[menu.lang]]
+  name = "🇬🇧 English"
+  url = "en"
+  weight = 1
+
+[[menu.lang]]
+  name = "🇨🇿 Czech"
+  url = "cs"
+  weight = 2
+
+[[menu.lang]]
+  name = "🇩🇪 German"
+  url = "de"
+  weight = 3
+
+[[menu.lang]]
+  name = "🇪🇸 Spanish"
+  url = "es"
+  weight = 4
+
+[[menu.lang]]
+  name = "🇫🇷 French"
+  url = "fr"
+  weight = 5
+
+[[menu.lang]]
+  name = "🇭🇺 Hungarian"
+  url = "hu"
+  weight = 6
+
+[[menu.lang]]
+  name = "🇮🇹 Italian"
+  url = "it"
+  weight = 7
+
+[[menu.lang]]
+  name = "🇯🇵 Japanese"
+  url = "ja"
+  weight = 8
+
+[[menu.lang]]
+  name = "🇰🇷 Korean"
+  url = "ko"
+  weight = 9
+
+[[menu.lang]]
+  name = "🇱🇹 Lithuanian"
+  url = "lt"
+  weight = 10
+
+[[menu.lang]]
+  name = "🇳🇱 Dutch"
+  url = "nl"
+  weight = 11
+
+[[menu.lang]]
+  name = "🇧🇷 Portuguese - Brazil"
+  url = "pt_BR"
+  weight = 12
+
+[[menu.lang]]
+  name = "🇵🇹 Portuguese - Portugal"
+  url = "pt_PT"
+  weight = 13
+
+[[menu.lang]]
+  name = "🇷🇴 Romanian"
+  url = "ro"
+  weight = 14
+
+[[menu.lang]]
+  name = "🇷🇺 Russian"
+  url = "ru"
+  weight = 15
+
+[[menu.lang]]
+  name = "🇨🇳 Chinese - Simplified"
+  url = "zh-Hans"
+  weight = 16
+
 [outputs]
   home = ["HTML", "RSS", "JSON", "version", "version-ltr", "version-json"]
 
@@ -490,3 +571,5 @@ sectionPagesMenu = 'main'
   baseName = "version"
   isPlainText = true
   mediaType = "application/json"
+
+

--- a/content/resources/hub.md
+++ b/content/resources/hub.md
@@ -6,6 +6,7 @@ draft: false
 sidebar: true
 Reviewed: 4 June 2024
 Reviewer: Tim Sutton
+selected_language: "en"
 ---
 
 {{< content-start  >}}
@@ -30,29 +31,32 @@ You will find documentation for every QGIS Long Term Release (LTR) on the respec
 
 [Get involved]({{< ref "/community/involve" >}}) and help us write a better documentation.
 
+{{< language-select >}}
+<span id="selected-language-display">Select a language</span>
+
 {{< tabs tab1="QGIS |ltrversion|" tab2="QGIS |version|" tab3="QGIS testing" tab4="Archived releases">}}
 
 
 {{< tab-content-start tab="1" >}}
 **For users (QGIS {{< param "ltrversion" >}}):**
 
-{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/en/docs/user_manual"  layoutClass="inline-block" listTitle="Desktop User Guide" >}}
+{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/<lang>/docs/user_manual"  layoutClass="inline-block link-with-language" listTitle="Desktop User Guide — <lang>" >}}
  
-{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/en/docs/training_manual"  layoutClass="inline-block" listTitle="QGIS Training manual">}}
+{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/<lang>/docs/training_manual"  layoutClass="inline-block link-with-language" listTitle="QGIS Training manual — <lang>">}}
 
-{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/en/docs/gentle_gis_introduction"  layoutClass="inline-block" listTitle="Gentle Intro to GIS" >}}
+{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/<lang>/docs/gentle_gis_introduction"  layoutClass="inline-block link-with-language" listTitle="Gentle Intro to GIS — <lang>" >}}
 
-{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/en/docs/server_manual"  layoutClass="inline-block" listTitle="Server Guide" >}}
+{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/<lang>/docs/server_manual"  layoutClass="inline-block link-with-language" listTitle="Server Guide — <lang>" >}}
 
 
 **For documentation writers (QGIS {{< param "ltrversion" >}}):**
 
-{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/en/docs/documentation_guidelinesion"  layoutClass="inline-block" listTitle="Documentation Guidelines">}}
+{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/<lang>/docs/documentation_guidelinesion"  layoutClass="inline-block link-with-language" listTitle="Documentation Guidelines — <lang>">}}
 
 
 **For developers (QGIS {{< param "ltrversion" >}}):**
 
-{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/en/docs/pyqgis_developer_cookbook"  layoutClass="inline-block" listTitle="PyQGIS cookbook (for plugins and scripting)">}}
+{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/<lang>/docs/pyqgis_developer_cookbook"  layoutClass="inline-block link-with-language" listTitle="PyQGIS cookbook (for plugins and scripting) — <lang>">}}
 
 {{< rich-list listLink="https://qgis.org/pyqgis/|ltrversion|/"  layoutClass="inline-block" listTitle="PyQGIS - QGIS Python Api documentation" >}}
 
@@ -74,22 +78,22 @@ You will find documentation for every QGIS Long Term Release (LTR) on the respec
 {{< tab-content-start tab="2" >}}
 **For users (QGIS {{< param "version" >}}):**
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/en/docs/user_manual"  layoutClass="inline-block" listTitle="Desktop User Guide" >}}
+{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/user_manual"  layoutClass="inline-block link-with-language" listTitle="Desktop User Guide — <lang>" >}}
   
-{{< rich-list listLink="https://docs.qgis.org/|version|/en/docs/training_manual"  layoutClass="inline-block" listTitle="QGIS Training Manual">}}
+{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/training_manual"  layoutClass="inline-block link-with-language" listTitle="QGIS Training Manual — <lang>">}}
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/en/docs/gentle_gis_introduction"  layoutClass="inline-block" listTitle="Gentle Intro to GIS" >}}
+{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/gentle_gis_introduction"  layoutClass="inline-block link-with-language" listTitle="Gentle Intro to GIS — <lang>" >}}
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/en/docs/server_manual"  layoutClass="inline-block" listTitle="Server Guide/Manual" >}}
+{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/server_manual"  layoutClass="inline-block link-with-language" listTitle="Server Guide/Manual — <lang>" >}}
 
 **For documentation writers (QGIS {{< param "version" >}}):**
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/en/docs/documentation_guidelinesion"  layoutClass="inline-block" listTitle="Documentation Guidelines">}}
+{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/documentation_guidelinesion"  layoutClass="inline-block link-with-language" listTitle="Documentation Guidelines — <lang>">}}
 
 
 **For developers (QGIS {{< param "version" >}}):**
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/en/docs/pyqgis_developer_cookbook"  layoutClass="inline-block" listTitle="PyQGIS cookbook (for plugins and scripting)">}}
+{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/pyqgis_developer_cookbook"  layoutClass="inline-block link-with-language" listTitle="PyQGIS cookbook (for plugins and scripting) — <lang>">}}
 
 {{< rich-list listLink="https://qgis.org/api/|version|/"  layoutClass="inline-block" listTitle="C++ API documentation" listSubtitle="">}}
 
@@ -115,15 +119,15 @@ We are still updating (not translating yet) the documentation for releases newer
 
 {{< tab-content-start tab="4" >}}
 
-{{< rich-list listLink="https://docs.qgis.org/3.22/en"  layoutClass="inline-block" listTitle="QGIS 3.22 Documentation" >}}
+{{< rich-list listLink="https://docs.qgis.org/3.22/<lang>"  layoutClass="inline-block link-with-language" listTitle="QGIS 3.22 Documentation — <lang>" >}}
 
-{{< rich-list listLink="https://docs.qgis.org/3.16/en"  layoutClass="inline-block" listTitle="QGIS 3.16 Documentation" >}}
+{{< rich-list listLink="https://docs.qgis.org/3.16/<lang>"  layoutClass="inline-block link-with-language" listTitle="QGIS 3.16 Documentation — <lang>" >}}
 
-{{< rich-list listLink="https://docs.qgis.org/3.10/en"  layoutClass="inline-block" listTitle="QGIS 3.10 Documentation" >}}
+{{< rich-list listLink="https://docs.qgis.org/3.10/<lang>"  layoutClass="inline-block link-with-language" listTitle="QGIS 3.10 Documentation — <lang>" >}}
 
-{{< rich-list listLink="https://docs.qgis.org/3.4/en"  layoutClass="inline-block" listTitle="QGIS 3.4 Documentation" >}}
+{{< rich-list listLink="https://docs.qgis.org/3.4/<lang>"  layoutClass="inline-block link-with-language" listTitle="QGIS 3.4 Documentation — <lang>" >}}
 
-{{< rich-list listLink="https://docs.qgis.org/2.18/en"  layoutClass="inline-block" listTitle="QGIS 2.18 Documentation" >}}
+{{< rich-list listLink="https://docs.qgis.org/2.18/<lang>"  layoutClass="inline-block link-with-language" listTitle="QGIS 2.18 Documentation — <lang>" >}}
 
 {{< tab-content-end >}}
 

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma.sass
@@ -179,7 +179,7 @@ $widescreen-enabled: false
 // Update some of Bulma's component variables
 $body-background-color: $white
 $control-border-width: 1px
-$input-border-color: light1
+$input-border-color: $light1
 $input-shadow: none
 $box-shadow: none
 $box-radius: {{ .Param "corner-radius" }}

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/form/select.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/form/select.sass
@@ -19,6 +19,7 @@ $select-colors: $form-colors !default
       +ltr-property("padding", 1em, false)
   select
     @extend %input
+    border-color: $grey-light
     cursor: pointer
     display: block
     font-size: 1em

--- a/themes/hugo-bulma-blocks-theme/assets/sass/style.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/style.sass
@@ -121,3 +121,8 @@ code
     padding: 0
     img
       border-radius: 10px
+
+.language-select-container
+  background-color: #ecf1f4
+  border-radius: 10px
+  color: #4d6370 !important

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/language-select.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/language-select.html
@@ -1,0 +1,59 @@
+{{ $selectedLang := .Page.Params.selected_language }}
+<div class="language-select-container p-5 mb-5 mt-5">
+    <div class="field is-flex is-align-items-center" style="gap: 10px;">
+        <label class="mb-0 has-text-weight-medium">Choose your language:</label>
+        <div class="control has-icons-left">
+            <div class="select">
+                <select>
+                    {{ range .Site.Menus.lang }}
+                    <option value="{{ .URL }}" {{ if eq .URL $selectedLang }}selected{{ end }}>
+                        {{ .Name }}
+                    </option>
+                    {{ end }}
+                </select>
+            </div>
+            <div class="icon is-small is-left">
+                <i class="fas fa-globe"></i>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const selectElement = document.querySelector('.language-select-container .select select');
+        const linkTitleWithLang = document.querySelectorAll('.link-with-language .listcont');
+        const linkWithLang = document.querySelectorAll('.link-with-language');
+
+        // Function to update URLs
+        function updateLinks(languageCode, languageText) {
+            linkWithLang.forEach(function (link) {
+                const url = link.getAttribute('data-url');
+                // Replace placeholder <lang> with the selected language
+                const newUrl = url.replace('%3clang%3e', languageCode);
+                link.setAttribute('href', newUrl);
+            });
+
+            linkTitleWithLang.forEach(function (title) {
+                const titleContent = title.getAttribute('title-content')
+                console.log(titleContent)
+                const newTitleContent = titleContent.replace('<lang>', languageText)
+                console.log(newTitleContent)
+                title.textContent = newTitleContent
+            });
+        }
+
+
+        if (selectElement) {
+            // Initialize with default language
+            let selectedOption = selectElement.options[selectElement.selectedIndex];
+            updateLinks(selectElement.value, selectedOption.text);
+
+            selectElement.addEventListener('change', function () {
+                let selectedOption = selectElement.options[selectElement.selectedIndex];
+                updateLinks(selectElement.value, selectedOption.text);
+            });
+        }
+    });
+</script>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/rich-list.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/rich-list.html
@@ -32,6 +32,7 @@
     <a
         class="rich-list {{ $layoutClass }} {{ $iconClass }} {{ $imageClass }} mr-2 mb-2"
         href="{{ $url }}"
+        data-url="{{ $url }}"
         target="{{ $target }}"
         rel="{{ $rel }}"
         {{ .Get "linkAttr" }}
@@ -42,7 +43,7 @@
         {{ with .Get "image" }}
             <div class="image"><img src="{{ . }}"></div>
         {{ end }}
-        <div class="listcont {{ $externalClass }}">{{ $listTitle }}</div>
+        <div class="listcont {{ $externalClass }}" title-content="{{ $listTitle }}">{{ $listTitle }}</div>
         <div class="subtext is-size-7">{{ $listSubtitle }}</div>
     </a>
 {{ else }}


### PR DESCRIPTION
Proposed fix for #344 

English is selected by default:

![image](https://github.com/user-attachments/assets/3bf6f68b-daaf-4b67-8131-ed94002f9f52)

When choosing another language, the link and description for each documentation are updated automatically 

![image](https://github.com/user-attachments/assets/987c5985-5b0b-48d0-9035-a54c18bf7aed)

Here are the list of available languages based on the docs website

![image](https://github.com/user-attachments/assets/c7cae4d7-fc13-4076-9be4-07a7a1cf8de5)
