### PR TITLE
Replace QGIS 3.38 docs links with QGIS testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Example usage as shortcode param:
 tricky part: shortcodes can't be used as other shortcodes' params. So you need to make replacement in the outer shortcode: "tabs.html" make a replacement of `|ltrversion|` and `|version|` to the values from config.
 
 ```
-{{< tabs tab1="QGIS |ltrversion|" tab2="QGIS |version|" tab3="QGIS testing" tab4="Archived releases">}}
+{{< tabs tab1="QGIS |ltrversion|" tab2="QGIS |version|" tab3="QGIS testing (>|ltrversion|)" tab4="Archived releases">}}
 ```
 
 ## URL mapping from old site structure

--- a/content/resources/hub.md
+++ b/content/resources/hub.md
@@ -34,7 +34,7 @@ You will find documentation for every QGIS Long Term Release (LTR) on the respec
 {{< language-select >}}
 <span id="selected-language-display">Select a language</span>
 
-{{< tabs tab1="QGIS |ltrversion|" tab2="QGIS |version|" tab3="QGIS testing" tab4="Archived releases">}}
+{{< tabs tab1="QGIS |ltrversion|" tab2="QGIS testing" tab3="Archived releases">}}
 
 
 {{< tab-content-start tab="1" >}}
@@ -51,7 +51,7 @@ You will find documentation for every QGIS Long Term Release (LTR) on the respec
 
 **For documentation writers (QGIS {{< param "ltrversion" >}}):**
 
-{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/<lang>/docs/documentation_guidelinesion"  layoutClass="inline-block link-with-language" listTitle="Documentation Guidelines — <lang>">}}
+{{< rich-list listLink="https://docs.qgis.org/|ltrversion|/<lang>/docs/documentation_guidelines"  layoutClass="inline-block link-with-language" listTitle="Documentation Guidelines — <lang>">}}
 
 
 **For developers (QGIS {{< param "ltrversion" >}}):**
@@ -76,24 +76,27 @@ You will find documentation for every QGIS Long Term Release (LTR) on the respec
 
 
 {{< tab-content-start tab="2" >}}
-**For users (QGIS {{< param "version" >}}):**
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/user_manual"  layoutClass="inline-block link-with-language" listTitle="Desktop User Guide — <lang>" >}}
+We are still updating (not translating yet) the documentation for releases newer than QGIS {{< param "ltrversion" >}}. We call this version 'QGIS Testing' and the documentation can be found here: 
+
+**For users (QGIS testing):**
+
+{{< rich-list listLink="https://docs.qgis.org/testing/en/docs/user_manual"  layoutClass="inline-block link-with-language" listTitle="Desktop User Guide" >}}
   
-{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/training_manual"  layoutClass="inline-block link-with-language" listTitle="QGIS Training Manual — <lang>">}}
+{{< rich-list listLink="https://docs.qgis.org/testing/en/docs/training_manual"  layoutClass="inline-block link-with-language" listTitle="QGIS Training Manual">}}
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/gentle_gis_introduction"  layoutClass="inline-block link-with-language" listTitle="Gentle Intro to GIS — <lang>" >}}
+{{< rich-list listLink="https://docs.qgis.org/testing/en/docs/gentle_gis_introduction"  layoutClass="inline-block link-with-language" listTitle="Gentle Intro to GIS" >}}
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/server_manual"  layoutClass="inline-block link-with-language" listTitle="Server Guide/Manual — <lang>" >}}
+{{< rich-list listLink="https://docs.qgis.org/testing/en/docs/server_manual"  layoutClass="inline-block link-with-language" listTitle="Server Guide/Manual" >}}
 
-**For documentation writers (QGIS {{< param "version" >}}):**
+**For documentation writers (QGIS testing):**
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/documentation_guidelinesion"  layoutClass="inline-block link-with-language" listTitle="Documentation Guidelines — <lang>">}}
+{{< rich-list listLink="https://docs.qgis.org/testing/en/docs/documentation_guidelines"  layoutClass="inline-block link-with-language" listTitle="Documentation Guidelines">}}
 
 
-**For developers (QGIS {{< param "version" >}}):**
+**For developers (QGIS testing):**
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/pyqgis_developer_cookbook"  layoutClass="inline-block link-with-language" listTitle="PyQGIS cookbook (for plugins and scripting) — <lang>">}}
+{{< rich-list listLink="https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook"  layoutClass="inline-block link-with-language" listTitle="PyQGIS cookbook (for plugins and scripting)">}}
 
 {{< rich-list listLink="https://qgis.org/api/|version|/"  layoutClass="inline-block" listTitle="C++ API documentation" listSubtitle="">}}
 
@@ -101,23 +104,16 @@ You will find documentation for every QGIS Long Term Release (LTR) on the respec
 
 {{< rich-list listLink="https://github.com/qgis/QGIS/blob/release-|version|/INSTALL.md"  layoutClass="inline-block" listTitle="Building QGIS from Source" >}}
 
-**For download (QGIS {{< param "version" >}}):**
+**For download (QGIS testing):**
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/pdf"  layoutClass="inline-block" listTitle="PDF of the manuals" >}}
+{{< rich-list listLink="https://docs.qgis.org/testing/pdf"  layoutClass="inline-block" listTitle="PDF of the manuals" >}}
 
-{{< rich-list listLink="https://docs.qgis.org/|version|/zip"  layoutClass="inline-block" listTitle="HTML zip of the manuals" >}}
+{{< rich-list listLink="https://docs.qgis.org/testing/zip"  layoutClass="inline-block" listTitle="HTML zip of the manuals" >}}
 
 {{< tab-content-end >}}
 
 {{< tab-content-start tab="3" >}}
 
-We are still updating (not translating yet) the documentation for releases newer than QGIS {{< param "version" >}}. We call this version 'QGIS Testing' and the documentation can be found here: 
-
-{{< rich-list listLink="https://docs.qgis.org/testing"  layoutClass="inline-block" listTitle="QGIS testing" >}}
-
-{{< tab-content-end >}}
-
-{{< tab-content-start tab="4" >}}
 
 {{< rich-list listLink="https://docs.qgis.org/3.22/<lang>"  layoutClass="inline-block link-with-language" listTitle="QGIS 3.22 Documentation — <lang>" >}}
 

--- a/content/resources/hub.md
+++ b/content/resources/hub.md
@@ -34,7 +34,7 @@ You will find documentation for every QGIS Long Term Release (LTR) on the respec
 {{< language-select >}}
 <span id="selected-language-display">Select a language</span>
 
-{{< tabs tab1="QGIS |ltrversion|" tab2="QGIS testing" tab3="Archived releases">}}
+{{< tabs tab1="QGIS |ltrversion|" tab2="QGIS testing (>|ltrversion|)" tab3="Archived releases">}}
 
 
 {{< tab-content-start tab="1" >}}

--- a/playwright/ci-test/tests/fixtures/project-page.ts
+++ b/playwright/ci-test/tests/fixtures/project-page.ts
@@ -26,7 +26,6 @@ export class ProjectPage {
         "Create maps",
         "Edit layers",
         "Process and analyze",
-        "Share maps",
         "Class-leading cartography",
         "Professional map production",
         "Powerful reporting tools",

--- a/playwright/ci-test/tests/fixtures/project-page.ts
+++ b/playwright/ci-test/tests/fixtures/project-page.ts
@@ -26,6 +26,7 @@ export class ProjectPage {
         "Create maps",
         "Edit layers",
         "Process and analyze",
+        "Share maps",
         "Class-leading cartography",
         "Professional map production",
         "Powerful reporting tools",

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/language-select.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/language-select.html
@@ -37,9 +37,7 @@
 
             linkTitleWithLang.forEach(function (title) {
                 const titleContent = title.getAttribute('title-content')
-                console.log(titleContent)
                 const newTitleContent = titleContent.replace('<lang>', languageText)
-                console.log(newTitleContent)
                 title.textContent = newTitleContent
             });
         }

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/tabs.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/tabs.html
@@ -1,7 +1,6 @@
 {{ $tab1 := .Get "tab1" }}
 {{ $tab2 := .Get "tab2" }}
 {{ $tab3 := .Get "tab3" }}
-{{ $tab4 := .Get "tab4" }}
 
 {{ with index .Site.Data.conf }}
 	{{ $tab1 = replace $tab1 "|ltrversion|" .ltrversion }}
@@ -18,9 +17,6 @@
         {{ end }}
         {{ if $tab3 }}
             <li><a id="tab-3">{{ $tab3 }}</a></li>
-        {{ end }}
-        {{ if $tab4 }}
-            <li><a id="tab-4">{{ $tab4 }}</a></li>
         {{ end }}
     </ul>
 </div>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/tabs.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/tabs.html
@@ -5,7 +5,7 @@
 
 {{ with index .Site.Data.conf }}
 	{{ $tab1 = replace $tab1 "|ltrversion|" .ltrversion }}
-	{{ $tab2 = replace $tab2 "|version|" .version }}
+	{{ $tab2 = replace $tab2 "|ltrversion|" .ltrversion }}
 {{ end }}
 
 <div class="tabs">

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/tabs.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/tabs.html
@@ -1,6 +1,7 @@
 {{ $tab1 := .Get "tab1" }}
 {{ $tab2 := .Get "tab2" }}
 {{ $tab3 := .Get "tab3" }}
+{{ $tab4 := .Get "tab4" }}
 
 {{ with index .Site.Data.conf }}
 	{{ $tab1 = replace $tab1 "|ltrversion|" .ltrversion }}
@@ -17,6 +18,9 @@
         {{ end }}
         {{ if $tab3 }}
             <li><a id="tab-3">{{ $tab3 }}</a></li>
+        {{ end }}
+        {{ if $tab4 }}
+            <li><a id="tab-4">{{ $tab4 }}</a></li>
         {{ end }}
     </ul>
 </div>


### PR DESCRIPTION
This is the proposed fix #330 

- Replace QGIS 3.38 with QGIS testing
- Update some of the links the links to /testing/: all links related to docs.qgis.org
- Some links still use the latest version in the link as they don't have the testing version available: https://qgis.org/api/3.38/, https://qgis.org/pyqgis/3.38/, https://github.com/qgis/QGIS/blob/release-3_38/INSTALL.md 
- Remove language changing feature for all links in QGIS testing as they don't have translated versions

![image](https://github.com/user-attachments/assets/e5c65a68-8fb8-40e1-95cc-02077ac72276)
