### PR TITLE
Limit roadmap schedule table width to 100%

### DIFF
--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/roadmap.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/roadmap.sass
@@ -219,3 +219,7 @@ div
 .right-ribbon .development::after
   border-right: 3px solid #4D6370
   border-top: 3px solid #4D6370
+
+.schedule-container
+  max-width: 100%
+  overflow: auto

--- a/themes/hugo-bulma-blocks-theme/assets/sass/style.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/style.sass
@@ -126,3 +126,5 @@ code
   background-color: #ecf1f4
   border-radius: 10px
   color: #4d6370 !important
+  select
+    max-width: 50vw

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/csv-table.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/csv-table.html
@@ -4,24 +4,26 @@
 {{ else }}
     {{ $data = .Inner | unmarshal }}
 {{ end }}
-<table class="roadmap">
-    <thead>
-        <tr>
-            {{ range index $data 0 }}
-                <th>{{ . }}</th>
-            {{ end }}
-        </tr>
-    </thead>
-    <tbody>
-        {{ range after 1 $data }}
+<div class="schedule-container">
+    <table class="roadmap">
+        <thead>
             <tr>
-            {{ range . }}
-                {{ $class := index (findRE ":rm-\\w+:" .) 0 }}
-                <td class="{{ trim $class ":" }}">
-                    {{ . | replaceRE ":rm-\\w+:" "" }}
-                </td>
-            {{ end }}
+                {{ range index $data 0 }}
+                    <th>{{ . }}</th>
+                {{ end }}
             </tr>
-        {{ end }}
-    </tbody>
-</table>
+        </thead>
+        <tbody>
+            {{ range after 1 $data }}
+                <tr>
+                {{ range . }}
+                    {{ $class := index (findRE ":rm-\\w+:" .) 0 }}
+                    <td class="{{ trim $class ":" }}">
+                        {{ . | replaceRE ":rm-\\w+:" "" }}
+                    </td>
+                {{ end }}
+                </tr>
+            {{ end }}
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
- Set a limit for the roadmap schedule table width as it stretches the navigation bar on mobile. Scrolling to the right will show other columns.

https://github.com/user-attachments/assets/480ae766-8dcf-4c9b-bfb3-665b9674642c

