### PR TITLE
Some fixes for the GH issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_shownotes.yml
+++ b/.github/ISSUE_TEMPLATE/bug_shownotes.yml
@@ -1,5 +1,5 @@
 name: Show Errors
-description: For problems with an episode itself (links, sponsors, typos, etc)
+description: For problems with a page itself (links, sponsors, typos, etc).
 labels:
   - bug
   - show notes

--- a/.github/ISSUE_TEMPLATE/bug_website.yml
+++ b/.github/ISSUE_TEMPLATE/bug_website.yml
@@ -25,6 +25,22 @@ body:
         - Tablet
         - Desktop
   - type: dropdown
+    id: operating_systems
+    attributes:
+      label: On which operating system(s) are you seeing the problem?
+      multiple: true
+      options:
+        - Android
+        - iOS
+        - Linux distribution
+        - MacOs
+        - Windows
+  - type: input
+    id: other_os
+    attributes:
+      label: Other OS
+      description: If your operating system is not in the list, enter it here.
+  - type: dropdown
     id: browsers
     attributes:
       label: On which browser(s) are you seeing the problem?

--- a/.github/ISSUE_TEMPLATE/dev.yml
+++ b/.github/ISSUE_TEMPLATE/dev.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Tools
       description: What tool(s) are affected?
-      placeholder: Docker, GH Actions, Make, etc.
+      placeholder: Hugo, IDE, Docker, GH Actions, Make, etc.
   - type: textarea
     id: summary
     attributes:


### PR DESCRIPTION
Fix for #402 

- Replace `episode` with `page`

![image](https://github.com/user-attachments/assets/856e09b9-7cfd-425e-acdd-e0b1ff957f4c)

- Add OS choices for Bug report

![image](https://github.com/user-attachments/assets/8217abe1-660c-4b8c-967e-05e87949e15a)
