### PR TITLE
Hide nightly builds link on macOS

### DIFF
--- a/content/resources/installation-guide/index.md
+++ b/content/resources/installation-guide/index.md
@@ -571,9 +571,11 @@ Spack related issues should be reported at: https://github.com/spack/spack/issue
 
 Official All-in-one, signed installers for macOS High Sierra (10.13) and newer can be downloaded from the [QGIS download page]({{< ref "download" >}}).
 
+<!--
 ## QGIS nightly release
 
 A nightly updated standalone installer from QGIS master can be downloaded from [here](/downloads/macos/qgis-macos-nightly.dmg).
+-->
 
 ## MacPorts
 

--- a/playwright/ci-test/tests/fixtures/installation-guide-page.ts
+++ b/playwright/ci-test/tests/fixtures/installation-guide-page.ts
@@ -91,7 +91,7 @@ export class InstallationGuidePage {
         "Flatpak",
         "Spack",
         "Mac OS X / macOS",
-        "QGIS nightly release",
+        // "QGIS nightly release",
         "MacPorts",
         "Old releases",
         "FreeBSD",


### PR DESCRIPTION
They are unavailable for years
At https://qgis.org/resources/installation-guide/#qgis-nightly-release you are directed to https://download.qgis.org//downloads/macos/qgis-macos-nightly.dmg for master downloads on macOS which is a forbidden URL. And actually no nightly/dev builds have occurred in the parent folder for months and years.

I suggest we hide the mention now and reopen when that macOS issue is solved.