### PR TITLE
Update certification.md

### DIFF
--- a/content/community/certification.md
+++ b/content/community/certification.md
@@ -11,9 +11,15 @@ Reviewer: Tim Sutton
 
 {{< content-start >}}
 
-# Become a certified trainer
+# Become a QGIS certified training organisation
+Is your organisation an active member of the QGIS community and offering high-quality training courses with QGIS? Then consider applying for the **QGIS Certification Programme**. As a member, you'll be able to issue the official QGIS certificate to participants of your courses, workshops and trainings. Each certificate contributes €20 to QGIS.
 
-The QGIS Certificate Program is designed to promote both community involvement in the QGIS project and quality education for QGIS software. The application process requires applicants to detail their contributions to the QGIS project and make their training materials available for review. Contributions to the QGIS project include activities such as:
+If you're looking for organisations that offer trainings with the official QGIS certificate, check the [current list of members](https://changelog.qgis.org/en/qgis/certifyingorganisation/list/) of the QGIS Certification Programme.
+
+## Certification Process
+### Requirements
+
+The QGIS Certification Programme is designed to promote both community involvement in the QGIS project and quality education for QGIS software. The application process requires applicants to detail their contributions to the QGIS project and make their training materials available for review. Contributions to the QGIS project include activities such as:
 
 *   Development/commits to QGIS
 *   Contributions to the QGIS documentation and training materials
@@ -27,15 +33,11 @@ The QGIS Certificate Program is designed to promote both community involvement i
 *   Authoring QGIS books
     
 
-To contact the certification team, please write to [certification@qgis.org](mailto:certification@qgis.org).
-
-## Certification Process
-
 ### Application
 
 You are required to provide the training material for each of your courses. This includes exercises, lectures and data. This material will be reviewed for currentness, accurate representation of the QGIS project and overall quality. If the material is not of adequate quality, this can be cause for refusal.
 
-Following an initial review, the application will be sent to local QGIS groups for their opinion. This part of the review should be completed within a month. If there is not a local QGIS user group, the QGIS Project Steering Committee (PSC) will make a determination based on material provided and your reputation in the community. In this latter case you are encouraged to establish a local QGIS User Group. If you are not considered a member in good standing of the QGIS community, this could be a reason for refusal.
+Following an initial review, the application will be sent to local [QGIS User Groups](https://qgis.org/community/groups/) for their opinion. This part of the review should be completed within a month. If there is not a local QGIS User Group, the QGIS Project Steering Committee (PSC) will make a determination based on material provided and your reputation in the community. In this latter case, you are encouraged to establish a local QGIS User Group. If you are not considered a member in good standing of the QGIS community, this could be a reason for refusal.
 
 The PSC will make the final determination. If accepted as a QGIS Certified Organization, your contributions to the project will be published for transparency.
 
@@ -43,8 +45,6 @@ If approved, you are required to pay a **€20 certification fee** to the QGIS p
 
 You can apply using [this form](https://changelog.qgis.org/en/qgis/create-certifyingorganisation/) (make sure to first create a [login](https://changelog.qgis.org/en/accounts/signup/)). You can find more details about the certification programme [here](https://changelog.qgis.org/en/qgis/about/) (we advise you to read this before registering).
 
-### Course Certification Workflow
-
-![Workflow Certification](../certificationworkflow.png "Workflow Certification")
+To contact the certification team, please write to [certification@qgis.org](mailto:certification@qgis.org).
 
 {{< content-end >}}

--- a/content/community/certification.md
+++ b/content/community/certification.md
@@ -12,9 +12,9 @@ Reviewer: Tim Sutton
 {{< content-start >}}
 
 # Become a QGIS certified training organisation
-Is your organisation an active member of the QGIS community and offering high-quality training courses with QGIS? Then consider applying for the **QGIS Certification Programme**. As a member, you'll be able to issue the official QGIS certificate to participants of your courses, workshops and trainings. Each certificate contributes €20 to QGIS.
+Is your organisation an active member of the QGIS community and offering high-quality training courses with QGIS? Then consider applying for the **QGIS Certification Programme**. As a member, you'll be able to issue the official QGIS certificate to participants of your courses, workshops and training. Each certificate contributes €20 to QGIS.
 
-If you're looking for organisations that offer trainings with the official QGIS certificate, check the [current list of members](https://changelog.qgis.org/en/qgis/certifyingorganisation/list/) of the QGIS Certification Programme.
+If you're looking for organisations that offer training with the official QGIS certificate, check the [current list of members](https://changelog.qgis.org/en/qgis/certifyingorganisation/list/) of the QGIS Certification Programme.
 
 ## Certification Process
 ### Requirements

--- a/playwright/ci-test/tests/04-community-page.spec.ts
+++ b/playwright/ci-test/tests/04-community-page.spec.ts
@@ -56,11 +56,11 @@ test.describe("Community pages", () => {
         await expect(communityPage.currencyInput).toBeVisible();
     });
 
-    test("Become a certified trainer", async ({ sidebar, communityPage }) => {
+    test("Become a QGIS certified training organisation", async ({ sidebar, communityPage }) => {
         await expect(sidebar.becomeCertifiedMemberLink).toBeVisible();
         await sidebar.becomeCertifiedMemberLink.click();
         let becomeCertifiedTexts = communityPage.textList.find(
-            (item) => item.page == "Become a certified trainer",
+            (item) => item.page == "Become a QGIS certified training organisation",
         )?.texts;
 
         if (becomeCertifiedTexts) {
@@ -68,8 +68,6 @@ test.describe("Community pages", () => {
                 await expect(communityPage.pageBody).toContainText(item);
             }
         }
-
-        await expect(communityPage.workflowCertificationImg).toBeVisible();
     });
     test("QGIS Foundation", async ({ sidebar, communityPage }) => {
         await expect(sidebar.qgisFoundationLink).toBeVisible();

--- a/playwright/ci-test/tests/fixtures/community-page.ts
+++ b/playwright/ci-test/tests/fixtures/community-page.ts
@@ -49,13 +49,13 @@ export class CommunityPage {
             ],
         },
         {
-            page: "Become a certified trainer",
+            page: "Become a QGIS certified training organisation",
             texts: [
-                "Become a certified trainer",
+                "Become a QGIS certified training organisation",
                 "certification@qgis.org",
                 "Certification Process",
-                "Application",
-                "Course Certification Workflow"
+                "Requirements",
+                "Application"
             ],
         },
         {


### PR DESCRIPTION
I've updated the certification page to make it clearer that it is for organisations. We receive a lot of applications from people who want a certificate and misunderstand the process.
I've dropped the flow chart, because it complicates the info provided and can be found on the projecta site.
Maybe we can include a picture of students with an official QGIS certificate, like the one attached here?
![2019-10-11 16 15 40](https://github.com/user-attachments/assets/8ff84a0b-ba71-4a89-80cf-152a68a93b47)

Fixes #430 

