### PR TITLE
Improvement for development version roadmap

### DIFF
--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
@@ -242,10 +242,13 @@
                 <div class="steps-content">
                     <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                         <span>
-                            Packaging
+                            Point Release:
+                            {{ with index .Site.Data.conf }}
+                                <span class="rm-future">{{ .nextversion }}</span>
+                            {{ end }}
                         </span>
                         <span class="help-tip">
-                            <span > Here we tag the release and make it available for packaging on different platforms.</span>
+                            <span>Every October, we release a new Long Term Release (LTR) and start a new development cycle.</span>
                         </span>
                     </div>
                     <div>
@@ -275,6 +278,18 @@
                                 </div>
                             </div>
                         </nav>
+                    </div>
+                </div>
+            </li>
+
+            <li class="steps-segment is-active">
+                <span class="steps-marker"></span>
+                <div class="steps-content">
+                    <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
+                        <span>Packaging</span>
+                        <span class="help-tip">
+                            <span > Here we tag the release and make it available for packaging on different platforms. </span>
+                        </span>
                     </div>
                 </div>
             </li>


### PR DESCRIPTION
Fix for #415 

- Added a new step: `Point Release: {{ nextversion }}`
- Move the packaging countdown to the `Point Release` step
- I've added the following help text to the `Point Release` step: "Every October, we release a new Long Term Release (LTR) and start a new development cycle."

![image](https://github.com/user-attachments/assets/966f3276-a91e-4751-9f4a-86a3e1e48177)

![image](https://github.com/user-attachments/assets/f53c8366-a2e4-49a7-a906-a3d4c47d6ab7)
