### PR TITLE
update roadmap: typo

### DIFF
--- a/content/resources/roadmap.md
+++ b/content/resources/roadmap.md
@@ -53,7 +53,7 @@ The schedule is aligned to produce roughly the same dates for each year given ou
 
 Beginning after 2.12 the development phase is always 12 weeks and the freeze phase is at least 5 weeks. Remainders are used to extend the freeze phase of LTR releases.
 
-Point releases will happen every month on the latest release branch branch, if there are backports. Beginning with the 3.28 release point releases are only done with new latest releases.
+Point releases will happen every month on the latest release branch, if there are backports. Beginning with the 3.28 release, point releases are only done with new latest releases.
 
 In the first four months after its release, a new LTR is also the current LR. In this phase, the new LTR doesn’t replace the previous LTR in the LTR repositories. This happens as soon as a new LR is released.
 


### PR DESCRIPTION
Removed duplicate word, added a comma.  😉 