### PR TITLE
Add missing 3.28 docs to Archives

### DIFF
--- a/content/resources/hub.md
+++ b/content/resources/hub.md
@@ -114,6 +114,8 @@ We are still updating (not translating yet) the documentation for releases newer
 {{< tab-content-start tab="3" >}}
 
 
+{{< rich-list listLink="https://docs.qgis.org/3.28/<lang>"  layoutClass="inline-block link-with-language" listTitle="QGIS 3.28 Documentation — <lang>" >}}
+
 {{< rich-list listLink="https://docs.qgis.org/3.22/<lang>"  layoutClass="inline-block link-with-language" listTitle="QGIS 3.22 Documentation — <lang>" >}}
 
 {{< rich-list listLink="https://docs.qgis.org/3.16/<lang>"  layoutClass="inline-block link-with-language" listTitle="QGIS 3.16 Documentation — <lang>" >}}


### PR DESCRIPTION
At https://www.qgis.org/resources/hub/ 3.28 is not mentioned among archived releases
![image](https://github.com/user-attachments/assets/f291947d-79f4-4e68-8402-111056a139fa)
