### PR TITLE
Remove mention of LTR for 3.4 in visual changelogs

### DIFF
--- a/content/project/visual-changelogs/visualchangelog34/index.md
+++ b/content/project/visual-changelogs/visualchangelog34/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Changelog for QGIS 3.4 LTR"
+title: "Changelog for QGIS 3.4"
 draft: false
 HasBanner: false
 sidebar: true
@@ -9,7 +9,7 @@ type: "visual-changelog"
 ---
 {{< content-start >}}
 
-# Changelog for QGIS 3.4 LTR {#changelog34}
+# Changelog for QGIS 3.4 {#changelog34}
 
 ![image0](images/entries/splash34vs.png)
 


### PR DESCRIPTION
It is the only one displaying that mention among all the versions listed at https://qgis.org/project/visual-changelogs/
![image](https://github.com/user-attachments/assets/6a70b5ed-e80a-489c-a159-f29270a903e7)

So either we remove it, either we add it to all the other LTR. I chose the easiest option.