### PR TITLE
Display the versions in the hub tabs

### DIFF
--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/tabs.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/tabs.html
@@ -5,7 +5,8 @@
 
 {{ with index .Site.Data.conf }}
 	{{ $tab1 = replace $tab1 "|ltrversion|" .ltrversion }}
-	{{ $tab2 = replace $tab2 "|ltrversion|" .ltrversion }}
+	{{ $tab2 = replace $tab2 "|version|" .version }}
+	{{ $tab3 = replace $tab3 "|version|" .version }}
 {{ end }}
 
 <div class="tabs">


### PR DESCRIPTION
Fix for #466 

- Replace |version| with the actual version in the tabs

<img width="704" alt="image" src="https://github.com/user-attachments/assets/4822a4a1-a886-49f4-ae6c-c555d5b73beb">
