### PR TITLE
Installation guide index

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -368,7 +368,131 @@ sectionPagesMenu = 'main'
   name = "Installation guide"
   url = "/resources/installation-guide/"
   weight = 10
+  [[menu.main]]
+    parent = "Installation guide"
+    name = "Windows"
+    url = "/resources/installation-guide/#windows"
+    weight = 20
 
+  [[menu.main]]
+    parent = "Windows"
+    name = "Standalone installers"
+    url = "/resources/installation-guide/#standalone-installers"
+    weight = 30
+
+  [[menu.main]]
+    parent = "Windows"
+    name = "OSGeo4W installer"
+    url = "/resources/installation-guide/#osgeo4w-installer"
+    weight = 40
+
+  [[menu.main]]
+    parent = "Installation guide"
+    name = "Linux"
+    url = "/resources/installation-guide/#linux"
+    weight = 50
+
+  [[menu.main]]
+    parent = "Linux"
+    name = "Debian / Ubuntu"
+    url = "/resources/installation-guide/#debian--ubuntu"
+    weight = 60
+
+  [[menu.main]]
+    parent = "Linux"
+    name = "Fedora"
+    url = "/resources/installation-guide/#fedora"
+    weight = 90
+
+  [[menu.main]]
+    parent = "Linux"
+    name = "NixOS"
+    url = "/resources/installation-guide/#nixos"
+    weight = 100
+
+  [[menu.main]]
+    parent = "Linux"
+    name = "SUSE / openSUSE"
+    url = "/resources/installation-guide/#suse--opensuse"
+    weight = 110
+
+  [[menu.main]]
+    parent = "Linux"
+    name = "Mandriva"
+    url = "/resources/installation-guide/#mandriva"
+    weight = 120
+
+  [[menu.main]]
+    parent = "Linux"
+    name = "Slackware"
+    url = "/resources/installation-guide/#slackware"
+    weight = 130
+
+  [[menu.main]]
+    parent = "Linux"
+    name = "Arch Linux"
+    url = "/resources/installation-guide/#arch-linux"
+    weight = 140
+
+  [[menu.main]]
+    parent = "Linux"
+    name = "Flatpak"
+    url = "/resources/installation-guide/#flatpak"
+    weight = 150
+
+  [[menu.main]]
+    parent = "Linux"
+    name = "Spack"
+    url = "/resources/installation-guide/#spack"
+    weight = 160
+
+  [[menu.main]]
+    parent = "Installation guide"
+    name = "Mac OS X / macOS"
+    url = "/resources/installation-guide/#mac-os-x--macos"
+    weight = 170
+
+  [[menu.main]]
+    parent = "Mac OS X / macOS"
+    name = "Binary packages (installers)"
+    url = "/resources/installation-guide/#binary-packages-installers"
+    weight = 180
+
+  [[menu.main]]
+    parent = "Mac OS X / macOS"
+    name = "MacPorts"
+    url = "/resources/installation-guide/#macports"
+    weight = 190
+
+  [[menu.main]]
+    parent = "Mac OS X / macOS"
+    name = "Old releases"
+    url = "/resources/installation-guide/#old-releases"
+    weight = 200
+
+  [[menu.main]]
+    parent = "Installation guide"
+    name = "FreeBSD"
+    url = "/resources/installation-guide/#freebsd"
+    weight = 210
+
+  [[menu.main]]
+    parent = "Installation guide"
+    name = "OpenBSD"
+    url = "/resources/installation-guide/#openbsd"
+    weight = 220
+
+  [[menu.main]]
+    parent = "Installation guide"
+    name = "QGIS Testing warning"
+    url = "/resources/installation-guide/#qgis-testing-warning"
+    weight = 230
+
+  [[menu.main]]
+    parent = "Installation guide"
+    name = "Installing from Source"
+    url = "/resources/installation-guide/#installing-from-source"
+    weight = 240
 
 [[menu.main]]
   parent = "Resources"

--- a/content/resources/installation-guide/index.md
+++ b/content/resources/installation-guide/index.md
@@ -77,7 +77,7 @@ Most linux distributions split QGIS into several packages; you’ll probably nee
 
 Below you will find specific instructions per distribution. For most distro’s there are instructions to install QGIS stable and instructions to install a cutting edge QGIS testing build (note the [warning](#warning)).
 
-## Debian/Ubuntu
+## Debian / Ubuntu
 
 ### Quickstart
 

--- a/playwright/ci-test/tests/06-resources-page.spec.ts
+++ b/playwright/ci-test/tests/06-resources-page.spec.ts
@@ -82,6 +82,13 @@ test.describe("Resources pages", () => {
     test("Installation guide", async ({ sidebar, installationGuidePage }) => {
         await expect(sidebar.installationGuideLink).toBeVisible();
         await sidebar.installationGuideLink.click();
+        await expect(sidebar.windowsLink).toBeVisible();
+        await expect(sidebar.linuxLink).toBeVisible();
+        await expect(sidebar.macOSLink).toBeVisible();
+        await expect(sidebar.freeBSDLink).toBeVisible();
+        await expect(sidebar.openBSDLink).toBeVisible();
+        await expect(sidebar.qgisTestingWarningLink).toBeVisible();
+        await expect(sidebar.installingFromSourceLink).toBeVisible();
         await expect(
             installationGuidePage.upcomingEvaluationLink,
         ).toBeVisible();

--- a/playwright/ci-test/tests/fixtures/installation-guide-page.ts
+++ b/playwright/ci-test/tests/fixtures/installation-guide-page.ts
@@ -127,6 +127,7 @@ export class InstallationGuidePage {
         });
         this.osgeo4WInstallerLink = this.page.getByRole("link", {
             name: "OSGeo4W Installer",
+            exact: true,
         });
         this.aptInstallGnupgPre = this.page
             .locator("pre")

--- a/playwright/ci-test/tests/fixtures/sidebar.ts
+++ b/playwright/ci-test/tests/fixtures/sidebar.ts
@@ -26,6 +26,13 @@ export class Sidebar {
     public readonly supportLink: Locator;
     public readonly membersLink: Locator;
     public readonly pastMembersLink: Locator;
+    public readonly windowsLink: Locator;
+    public readonly linuxLink: Locator;
+    public readonly macOSLink: Locator;
+    public readonly freeBSDLink: Locator;
+    public readonly openBSDLink: Locator;
+    public readonly qgisTestingWarningLink: Locator;
+    public readonly installingFromSourceLink: Locator;
 
     constructor(public readonly page: Page) {
         this.sidebar = this.page.locator("#sidebar");
@@ -81,11 +88,39 @@ export class Sidebar {
         this.membershipLink = this.sidebar.getByRole("link", {
             name: "Membership",
         });
-
         this.installationGuideLink = this.sidebar.getByRole("link", {
             name: "Installation guide",
         });
 
+        this.windowsLink = this.sidebar.getByRole("link", {
+            name: "Windows",
+        });
+
+        this.linuxLink = this.sidebar.getByRole("link", {
+            name: "Linux",
+            exact: true,
+        });
+
+        this.macOSLink = this.sidebar.getByRole("link", {
+            name: "Mac OS X / macOS",
+        });
+
+        this.freeBSDLink = this.sidebar.getByRole("link", {
+            name: "FreeBSD",
+        });
+
+        this.openBSDLink = this.sidebar.getByRole("link", {
+            name: "OpenBSD",
+        });
+
+        this.qgisTestingWarningLink = this.sidebar.getByRole("link", {
+            name: "QGIS Testing Warning",
+        });
+
+        this.installingFromSourceLink = this.sidebar.getByRole("link", {
+            name: "Installing from Source",
+        });
+        
         this.archiveLink = this.sidebar.getByRole("link", {
             name: "Archive",
             exact: true,


### PR DESCRIPTION
Proposed fix for #473 

Add submenus for "Installation guide"

![image](https://github.com/user-attachments/assets/e9805fa4-f2f2-4f03-b0c7-2d12a4b5719d)
