### PR TITLE
Redirect the news url to the feed detail

### DIFF
--- a/data/feed.json
+++ b/data/feed.json
@@ -5,6 +5,6 @@
     "title": "We Need Your Feedback on QGIS Documentation!",
     "image": "https://feed.qgis.org/media/feedimages/2024/11/20/docs-survey.jpg",
     "content": "<p>We're running a short, anonymous QGIS Documentation User Survey to gather feedback and improve our manuals, guides, and resources. Whether you're a beginner or an experienced user, your input will help us make the documentation better for everyone. The survey will remain open until December 20th.</p>\r\n<p>Please take a moment to share your thoughts!</p>\r\n<p><strong>Take the survey by double-clicking this entry.</strong></p>\r\n<p>Thank you for your time and support!</p>",
-    "url": "https://docs.google.com/forms/d/e/1FAIpQLSc69ojhNcnm_qWB5TOkwA_WZsn-IA0eKVzdk3dHoH7JCKm6vQ/viewform",
+    "url": "https://feed.qgis.org/89",
     "sticky": false
 }

--- a/fetch_feeds.py
+++ b/fetch_feeds.py
@@ -199,6 +199,7 @@ def fetch_first_feed_entry():
 
     if feed_data and len(feed_data) > 0:
         first_entry = feed_data[0]
+        first_entry['url'] = f"https://feed.qgis.org/{first_entry['pk']}"
         os.makedirs(os.path.dirname(feed_file_path), exist_ok=True)
         with open(feed_file_path, "w", encoding="utf-8") as f:
             json.dump(first_entry, f, ensure_ascii=False, indent=4)


### PR DESCRIPTION
Fix for #477 

This change depends on https://github.com/qgis/qgis-feed/pull/96 which adds a details page for each feed item.
The news link will be redirected to the feed item details page instead of the external URL of the feed. However, the external URL is still listed in the feed item details.