### PR TITLE
Fix e2e workflow by specifying hugo version instead of using latest

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -19,7 +19,10 @@ jobs:
       - name: 🛠️ Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: 'latest' # We will be alerted if our code has deprecated functions
+          # Using the latest value doesn't work for now. 
+          # See https://github.com/peaceiris/actions-hugo/issues/652#issuecomment-2543985304
+          # and https://github.com/peaceiris/actions-hugo/issues/662
+          hugo-version: '0.139.4'
           extended: true
 
       - name: 🧱 Hugo build


### PR DESCRIPTION
Fix for the failing e2e test. It seems that using the `latest` value for `peaceiris/actions-hugo@v3` doesn't work as mentioned at https://github.com/peaceiris/actions-hugo/issues/662