### PR TITLE
Add a section for portable version in the installation guide

### DIFF
--- a/content/resources/installation-guide/index.md
+++ b/content/resources/installation-guide/index.md
@@ -71,6 +71,10 @@ The Express installs reference the corresponding `-full` variant and the standal
 
 Before installing any of the nightly builds note the [warnings](#warning) below.
 
+## Portable version
+
+Currently, there is no official portable version of QGIS. However, you can refer to an example of a portable QGIS setup available [here](https://github.com/pigreco/QGIS_portable_3x). Please note that the instructions are provided in Italian.
+
 # Linux
 
 Most linux distributions split QGIS into several packages; you’ll probably need `qgis` and `qgis-python` (to run plugins). Packages like `qgis-grass` (or `qgis-plugin-grass`), `qgis-server` can be skipped initially, or installed only when you need them.

--- a/playwright/ci-test/tests/fixtures/installation-guide-page.ts
+++ b/playwright/ci-test/tests/fixtures/installation-guide-page.ts
@@ -74,6 +74,7 @@ export class InstallationGuidePage {
         "Windows",
         "Standalone installers",
         "OSGeo4W installer",
+        "Portable version",
         "Linux",
         "Debian/Ubuntu",
         "Quickstart",


### PR DESCRIPTION
Proposed fix for #414 

Hi @timlinux and @anitagraser , what do you think about adding this section?

![image](https://github.com/user-attachments/assets/5144f8b9-a5d0-4404-b309-b5f5e889f42c)
