### PR TITLE
Update explore video to 3.40 changelogs

### DIFF
--- a/themes/hugo-bulma-blocks-theme/layouts/partials/explore.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/partials/explore.html
@@ -71,7 +71,7 @@
         </div>
     </div>
     <div class="tile video">
-        <div class="youtube" data-video-id="oktjj7xBZ54">
+        <div class="youtube" data-video-id="2Pk-etS1HNo">
             <div class="play-button"></div>
         </div>
 


### PR DESCRIPTION
In the "[Start using QGIS](https://qgis.org/)" section in the main page, we are showing the 3.38 changelog video. Better use the 3.40's.
Even better, if we could automatize the change...