### PR TITLE
Fix version.json values

### DIFF
--- a/layouts/index.version-json.json
+++ b/layouts/index.version-json.json
@@ -16,11 +16,11 @@
     },
     "ltr": {
         "versionint": {{ printf "%d%02d%02d" (index $ltrrelease 0) (index $ltrrelease 1) (index $ltrrelease 2) }},
-	"version": "{{ .Params.ltrversion }}",
+	"version": "{{ .ltrversion }}",
         "name": "{{ .ltrcodename }}",
-        "note": "{{ .ltrreleasenote }}",
+        "note": "{{ .ltrnote }}",
         "binary": "{{ .ltrbinary }}",
-        "date": "{{ .ltrreleasedate }}",
+        "date": "{{ .releasedate }}",
         "major": {{ index $ltrrelease 0 }},
         "minor": {{ index $ltrrelease 1 }},
         "patch": {{ index $ltrrelease 2 }}


### PR DESCRIPTION
Some of the attributes at https://version.qgis.org/version.json currently show `<no value>`. This PR should fix them:

Currently:

![image](https://github.com/user-attachments/assets/255505f8-33e6-4498-90fc-00efddd77248)

After this PR:

![image](https://github.com/user-attachments/assets/6b9b9756-0126-4576-952d-38d757ceee9f)
