### PR TITLE
Download button emplacement

### DIFF
--- a/content/download/index.md
+++ b/content/download/index.md
@@ -25,11 +25,10 @@ Our very best regards!
 
 {{< rich-content-end >}}
 {{< rich-right-start mode="html" >}}
-{{< stripe-widget otherMethods="true" >}}
+{{< stripe-widget otherMethods="true" skipToDownload="true" >}}
 {{< rich-right-end >}}
 {{< rich-box-end >}}
 
-{{< hide-donate-prompt >}}
 
 {{< download-platforms-start >}}
 

--- a/content/thank-you/index.md
+++ b/content/thank-you/index.md
@@ -13,6 +13,17 @@ url: "/download/thank-you"
 
 ## Your freshly baked copy of QGIS is downloading. 
 
+{{< progress-bar autoHideAfter="60000">}}
+
+{{< rich-box-start icon="⬇️" layoutClass="tips">}}
+{{< rich-content-start themeClass="coloring-1" >}}
+##### Monitor Your Download
+Downloads may take a while. Please **monitor the progress** using your **download manager**.
+
+If your download didn't start, you can manually download QGIS from the [QGIS.org hosted downloads](https://download.qgis.org/downloads/).
+{{< rich-content-end >}}
+{{< rich-box-end >}}
+
 {{< rich-box-start layoutClass="qgis_first_conference mt-6">}}
 {{< rich-content-start >}}
 ![QGIS Developers 1st meeting](qgis_1st_conference.png "QGIS Developers 1st meeting")

--- a/content/thank-you/index.md
+++ b/content/thank-you/index.md
@@ -24,6 +24,25 @@ If your download didn't start, you can manually download QGIS from the [QGIS.org
 {{< rich-content-end >}}
 {{< rich-box-end >}}
 
+
+{{< rich-box-start mode="html" layoutClass="has-right" id="donate-prompt">}}
+{{< rich-content-start themeClass="coloring-2" >}}
+## Your support is vital to keep QGIS improving
+
+Our software is, and always will be, available free of charge if downloaded from QGIS.org.
+
+The project is a result of a huge effort and social contribution from many community members who volunteer their time and expertise. In addition, many businesses, government agencies and commercial entities have contributed to the development of QGIS. They do this either to ensure that QGIS meets their specific needs or to contribute to and accelerate the huge social impact that is realised by making a tool such as QGIS freely available. Our goal is the betterment of society through informed spatial decision making. If you are able, we gently request that you support our work.
+
+Whether you choose to donate or not, we hope that you enjoy using our labour of love and encourage you to share and spread your downloaded copy far and wide so that others may enjoy it too.
+
+Our very best regards!
+
+{{< rich-content-end >}}
+{{< rich-right-start mode="html" >}}
+{{< stripe-widget otherMethods="true" alreadyDonated="true">}}
+{{< rich-right-end >}}
+{{< rich-box-end >}}
+
 {{< rich-box-start layoutClass="qgis_first_conference mt-6">}}
 {{< rich-content-start >}}
 ![QGIS Developers 1st meeting](qgis_1st_conference.png "QGIS Developers 1st meeting")

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-platforms-end.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-platforms-end.html
@@ -2,8 +2,8 @@
 
 <script>
 function hidePrompt() {
-    document.getElementById('donate-prompt').remove();
-    document.getElementById('hide-donate-prompt').remove();
+    document.getElementById('donate-prompt').style.display = 'none';
+    // document.getElementById('hide-donate-prompt').remove();
     // uncomment next line to show donate-prompt only for the first time
     // localStorage.setItem('donatePromptClosed', true);
     document.getElementById('download-section').style.display = 'block';

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-platforms-end.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-platforms-end.html
@@ -47,7 +47,7 @@ function thanks(element) {
     window.open(element.href);
     // Redirect to thank you page after a short delay
     setTimeout(function() {
-        window.location.href += 'thank-you';
+        window.location.href = '/download/thank-you';
     }, 500);
 }
 </script>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-platforms-end.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-platforms-end.html
@@ -1,6 +1,13 @@
 </div>
 
 <script>
+document.addEventListener('DOMContentLoaded', function() {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('skip_donate') === 'true') {
+        hidePrompt();
+    }
+});
+
 function hidePrompt() {
     document.getElementById('donate-prompt').style.display = 'none';
     // document.getElementById('hide-donate-prompt').remove();

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/hide-donate-prompt.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/hide-donate-prompt.html
@@ -1,1 +1,0 @@
-<button class="button is-primary6" id="hide-donate-prompt" onclick="hidePrompt()">Skip it and go to download</button>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/progress-bar.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/progress-bar.html
@@ -1,0 +1,11 @@
+<progress id="fake-progress" class="progress is-medium is-primary1"></progress>
+{{ if .Get "autoHideAfter" }}
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            var autoHideAfter = {{ .Get "autoHideAfter" }};
+            setTimeout(function () {
+                document.getElementById("fake-progress").style.display = "none";
+            }, autoHideAfter);
+        });
+    </script>
+{{ end }}

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/stripe-widget.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/stripe-widget.html
@@ -37,9 +37,29 @@
             Skip it and go to download
         </button>
     {{ end }}
+    {{ if .Get "alreadyDonated" }}
+        <hr>
+        <button 
+            class="button is-primary6 is-fullwidth is-outlined" 
+            id="hide-donate-prompt" 
+            onclick="hidePrompt()">
+            Already donated? Hide this prompt
+        </button>
+    {{ end }}
 </div>
 
 {{ $donatejs := resources.Get "js/donate.js" | resources.Minify }}
-<script
-    src="{{ $donatejs.RelPermalink }}"
-></script>
+<script src="{{ $donatejs.RelPermalink }}"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        let pathname = window.location.pathname;
+        if (localStorage.getItem('donatePromptClosed') === 'true' && pathname.includes('/download/thank-you')) {
+            hidePrompt();
+        }
+    });
+    function hidePrompt() {
+        document.getElementById('donate-prompt').style.display = 'none';
+        localStorage.setItem('donatePromptClosed', 'true');
+        window.scrollTo(0, 0);
+    }
+</script>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/stripe-widget.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/stripe-widget.html
@@ -16,6 +16,7 @@
             class="button is-primary1"
             rel="noopener noreferrer"
             target="_blank"
+            onclick="hidePrompt()"
             {{/* href to be set by js depending on selected donation */}}
         >Donate
         </a>
@@ -29,6 +30,15 @@
         <option value="usd">USD</option>
       </select>
     </div>
+    {{ if .Get "skipToDownload" }}
+        <hr>
+        <button 
+            class="button is-primary6 is-fullwidth is-outlined" 
+            id="hide-donate-prompt" 
+            onclick="hidePrompt()">
+            Skip it and go to download
+        </button>
+    {{ end }}
 </div>
 
 {{ $donatejs := resources.Get "js/donate.js" | resources.Minify }}

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/stripe-widget.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/stripe-widget.html
@@ -15,8 +15,6 @@
             id="submit-button" 
             class="button is-primary1"
             rel="noopener noreferrer"
-            target="_blank"
-            onclick="hidePrompt()"
             {{/* href to be set by js depending on selected donation */}}
         >Donate
         </a>


### PR DESCRIPTION
Fix for #516 

## Changes summary
- Moved the **Skip and go to download** button below the **Donate** button to make it easier to find. See the 1st screen recording 
- Set the **Skip and go to download** button style to outline so it won't lower the visibility of the **Donate** button (or should we do the opposite)
- Clicking on the **Donate** button will trigger two actions: (1) open the donate page in a new tab and (2) Show the download page (with links) on the main tab. See the 2nd screen recording
- After downloading, the thank you page will show a fake progress bar that hides automatically after 1 minute and a note about checking the download manager

**Question:** Is it possible to automatically close the new stripe tab, or add a note to switch to the main tab when the user finishes the donate process



https://github.com/user-attachments/assets/d9d00820-ec20-4bea-8d44-44749813fe6f


https://github.com/user-attachments/assets/8d1a8875-d5ec-4fb9-a9b7-22e9d0c24545




