### PR TITLE
Use the params for versions in the fedora table

### DIFF
--- a/content/resources/installation-guide/index.md
+++ b/content/resources/installation-guide/index.md
@@ -330,10 +330,10 @@ Follow the `toolbx` and `distrobox` [instructions](#distrobox--toolbx).
 
 Fedora switches between the current QGIS release and the LTR releases. The unstable "Rawhide" branch will ship newer but possibly buggy QGIS versions.
 
-|Distribution|Version|QGIS version|GRASS GIS version|
+|Distribution|Version|QGIS version|
 |---|---|---|---|
-|Fedora|40|3.34.14|3.34.14|
-||41|3.40.2|3.40.2|
+|Fedora|40|{{< param "ltrversion" >}}.x {{< param "ltrcodename" >}} {{< param "ltrnote" >}}|
+||41|{{< param "version" >}}.x {{< param "codename" >}} {{< param "releasenote">}}|
 
 Always up-to-date version infos:
 - [QGIS](https://packages.fedoraproject.org/pkgs/qgis/qgis)

--- a/playwright/ci-test/tests/06-resources-page.spec.ts
+++ b/playwright/ci-test/tests/06-resources-page.spec.ts
@@ -160,9 +160,8 @@ test.describe("Resources pages", () => {
         ).toBeVisible();
         await expect(installationGuidePage.dnfInstallQgisPre).toBeVisible();
         await expect(installationGuidePage.distributionCell2).toBeVisible();
-        await expect(installationGuidePage.distGrassFedora).toBeVisible();
+        await expect(installationGuidePage.distQGISFedora).toBeVisible();
         await expect(installationGuidePage.qgisVersionCell).toBeVisible();
-        await expect(installationGuidePage.grassGisVersionCell).toBeVisible();
         await expect(installationGuidePage.rpmInstallQgis).toBeVisible();
         await expect(installationGuidePage.distributionCell3).toBeVisible();
         await expect(installationGuidePage.repositoryCell2).toBeVisible();

--- a/playwright/ci-test/tests/fixtures/installation-guide-page.ts
+++ b/playwright/ci-test/tests/fixtures/installation-guide-page.ts
@@ -40,9 +40,8 @@ export class InstallationGuidePage {
     public readonly aptUpdateInstallQgisServerPre: Locator;
     public readonly dnfInstallQgisPre: Locator;
     public readonly distributionCell2: Locator;
-    public readonly distGrassFedora: Locator;
+    public readonly distQGISFedora: Locator;
     public readonly qgisVersionCell: Locator;
-    public readonly grassGisVersionCell: Locator;
     public readonly rpmInstallQgis: Locator;
     public readonly distributionCell3: Locator;
     public readonly repositoryCell2: Locator;
@@ -231,19 +230,15 @@ export class InstallationGuidePage {
         this.distributionCell2 = this.page
             .getByRole("cell", { name: "Distribution" })
             .nth(1);
-        this.distGrassFedora = this.page
+        this.distQGISFedora = this.page
             .locator("table")
             .filter({
-                hasText:
-                    "Distribution Version QGIS version GRASS GIS version Fedora",
+                hasText: "Distribution Version QGIS version Fedora",
             })
             .locator("th")
             .nth(1);
         this.qgisVersionCell = this.page
             .getByRole("cell", { name: "QGIS version" })
-            .first();
-        this.grassGisVersionCell = this.page
-            .getByRole("cell", { name: "GRASS GIS version" })
             .first();
         this.rpmInstallQgis = this.page.locator("pre").filter({
             hasText:


### PR DESCRIPTION
Suggestion for https://github.com/qgis/QGIS-Website/pull/527#discussion_r1929508580

In the future, only the Fedora version column will need update.

Cc @agiudiceandrea @boredsquirrel 

![image](https://github.com/user-attachments/assets/b494a8c1-4a1d-42a9-842d-b9f84799a103)
