### PR TITLE
Add titles and short descriptions to windows installers

### DIFF
--- a/content/resources/installation-guide/index.md
+++ b/content/resources/installation-guide/index.md
@@ -28,7 +28,7 @@ In the feature frozen phase preceding a release (see [Release schedule]({{< ref 
 
 There are two options for installing on Windows:
 
-## Standalone installers
+## Offline (Standalone) installers
 
 Standalone installers include everything QGIS needs in a single download. Once you have the installer, no internet is required to complete the installation. When a new release is available, you need to download the complete installer again in order to upgrade. For beginners, the standlone installer is probably the easiest way to install QGIS:
 
@@ -40,7 +40,7 @@ Standalone installers include everything QGIS needs in a single download. Once y
 
 The weekly snapshots of the nightly qgis-dev package of OSGeo4W are for users that cannot use OSGeo4W (see below) for some reason or just prefer standalone installers. In the feature freeze phase, theset also act as **release candidate** installers.
 
-## OSGeo4W installer
+## Online (OSGeo4W) installer
 
 More advanced QGIS users should use OSGeo4W packages. This installer makes it possible to install several versions of QGIS in parallel and also to do much more efficient updates as only changed components are downloaded and installed with each new release.
 

--- a/playwright/ci-test/tests/fixtures/installation-guide-page.ts
+++ b/playwright/ci-test/tests/fixtures/installation-guide-page.ts
@@ -67,8 +67,8 @@ export class InstallationGuidePage {
     public readonly textList: string[] = [
         "QGIS Installers",
         "Windows",
-        "Standalone installers",
-        "OSGeo4W installer",
+        "Offline (Standalone) installers",
+        "Online (OSGeo4W) installer",
         "Linux",
         "Debian/Ubuntu",
         "Quickstart",

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-windows.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-windows.html
@@ -1,4 +1,24 @@
 {{ with index .Site.Data.conf }}
+
+<h2 class="title is-size-5">Online (OSGeo4W) installer:</h2>
+
+<a
+	class="button is-primary1 mb-3"
+	href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe"
+    onclick="thanks(this)"
+    download
+>OSGeo4W Network Installer</a>
+<br>
+<p>
+    This installer is the best way to keep QGIS up to date, 
+    run multiple versions on your system and keep the load 
+    on our download servers to a minimum. 
+    <a href="{{ absURL "resources/installation-guide#osgeo4w-installer" }}">
+        Learn more.
+    </a>
+</p>
+
+<h2 class="title is-size-5">Offline (Standalone) installers:</h2>
 <a
 	class="button is-primary1 mb-3"
 	href="{{ .ltr_msi }}"
@@ -20,17 +40,16 @@
     download
 >Latest Version for Windows ({{ .version }}) with Qt6 (experimental)</a>
 
-<br>
-The OSGeo4W installer is recommended for regular users or organization deployments. It allows to have several QGIS versions in one place, and to keep each component up-to-date individually without having to download the whole package.
+<p>
+    These installers are for users who wish 
+    to easily share the download e.g. putting 
+    it on a USB key or network share.
+    <a href="{{ absURL "resources/installation-guide#standalone-installers" }}">
+        Learn more.
+    </a>
+</p>
 
-<br>
-<a
-	class="button is-primary1 is-outlined mb-3"
-	href="{{ absURL "resources/installation-guide#osgeo4w-installer" }}"
-    onclick="thanks(this)"
-    download
->OSGeo4W Network Installer</a>
-<br>
-
-Since QGIS 3.20 we only ship 64-bit Windows executables.
+<p>
+    ⚠️ Since QGIS 3.20 we only ship 64-bit Windows executables.
+</p>
 {{ end }}


### PR DESCRIPTION
Proposed fix for #374 according to the discussion

- Added the title `Online (OSGeo4W) installer` and `Offline (Standalone) installers` for Windows installation options
- Updated the installation guide page accordingly 
- Added a short description to each installation option with a link (`Learn more`) to the installation guide section
- Filled the `OSGeo4W Network Installer` button and made it directly download the installer.

![image](https://github.com/user-attachments/assets/5883d3c3-51c7-413d-89df-75febe285ba9)

![image](https://github.com/user-attachments/assets/0ab8f217-5edf-4a92-ac1c-12c84e046604)
