### PR TITLE
Fix anchor links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -386,14 +386,14 @@ sectionPagesMenu = 'main'
 
   [[menu.main]]
     parent = "Windows"
-    name = "Standalone installers"
-    url = "/resources/installation-guide/#standalone-installers"
+    name = "Offline (Standalone) installers"
+    url = "/resources/installation-guide/#offline-standalone-installers"
     weight = 30
 
   [[menu.main]]
     parent = "Windows"
-    name = "OSGeo4W installer"
-    url = "/resources/installation-guide/#osgeo4w-installer"
+    name = "Online (OSGeo4W) installer"
+    url = "/resources/installation-guide/#online-osgeo4w-installer"
     weight = 40
 
   [[menu.main]]

--- a/content/download/index.md
+++ b/content/download/index.md
@@ -41,10 +41,10 @@ Our very best regards!
 GNU/Linux is a Free operating system built on the same principles that QGIS is built on.
 We provide installers for many flavors of GNU/Linux binary packages (including rpm and deb packages). Please select your choice of distro below:
 
-- [Debian/Ubuntu]({{< ref "resources/installation-guide#debianubuntu" >}})
+- [Debian/Ubuntu]({{< ref "resources/installation-guide#debian--ubuntu" >}})
 - [Fedora]({{< ref "resources/installation-guide#fedora" >}})
 - [NixOS]({{< ref "resources/installation-guide#nixos" >}})
-- [openSUSE]({{< ref "resources/installation-guide#suse-opensuse" >}})
+- [openSUSE]({{< ref "resources/installation-guide#suse--opensuse" >}})
 - [Mandriva]({{< ref "resources/installation-guide#mandriva" >}})
 - [Slackware]({{< ref "resources/installation-guide#slackware" >}})
 - [Arch Linux]({{< ref "resources/installation-guide#arch-linux" >}})

--- a/content/resources/roadmap.md
+++ b/content/resources/roadmap.md
@@ -82,8 +82,8 @@ This schedule is also available as [“iCalendar”](https://qgis.org/schedule.i
 
 |Platform|Location|
 |---|---|
-|Windows|[OSGeo4W]({{< ref "resources/installation-guide#osgeo4w-installer" >}})|
+|Windows|[OSGeo4W]({{< ref "resources/installation-guide#online-osgeo4w-installer" >}})|
 |Linux|[Debian/Ubuntu]({{< ref "resources/installation-guide#repositories" >}})|
-|MacOS|[Mac OS]({{< ref "resources/installation-guide#qgis-nightly-release" >}})|
+<!-- |MacOS|[Mac OS]({{< ref "resources/installation-guide#qgis-nightly-release" >}})| -->
 
 {{< content-end >}}

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -30,7 +30,7 @@ If you run a code scanner, most of the vulnerabilities listed are not related to
 OSGEO4W provides update scripts, allowing you to upgrade only the necessary libraries without the need to redownload the entire package. For more information on setting up these scripts for your deployment, refer to the [OSGEO4W documentation](https://trac.osgeo.org/osgeo4w/).
 
 
-On **[Ubuntu / Debian](/resources/installation-guide/#debianubuntu)**, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / PROJ / GRASS).
+On **[Ubuntu / Debian](/resources/installation-guide/#debian--ubuntu)**, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / PROJ / GRASS).
 For Python and Qt libraries, which rely on your operating system, please ensure they are updated regularly using your system's update manager. For Ubuntu/Debian, this typically involves using commands like `sudo apt update` and `sudo apt upgrade`.
 
 Other Linux distribution packages are maintained by the community, such as Conda, FlatPak, etc. Any issue should be raised to the downstream maintainers.  

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -55,7 +55,7 @@ QGIS server and QGIS Desktop have been written to limit the possibility of SQL i
 
 ## What to do if you think you have found a security issue
 
-If you believe you have found a security issue, such as vulnerabilities in QGIS or its dependencies, please refer to the [security page]({{< ref "resources/support/security" >}}) for detailed information on how to report it responsibly. Before this, please do the following:
+If you believe you have found a security issue, such as vulnerabilities in QGIS or its dependencies, please do the following:
 
  - Check you are using the latest version of QGIS, and have a glance at the nightly version for potential ongoing changes (fixes or regressions).
  - Check if your issue concerns QGIS desktop or QGIS server.

--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -25,9 +25,9 @@ Security issues in QGIS can arise in various scenarios, including, but not limit
 
 If you run a code scanner, most of the vulnerabilities listed are not related to QGIS, but to its dependencies. The specific version of the dependencies shipped with QGIS depends on the OS and packaging system being used. 
 
-**On Windows**, QGIS.org uses the OSGEO4W project to distribute a complete environment. The OSGEO4W build is fully maintained by the QGIS project.
+**On Windows**, QGIS.org uses the OSGeo4W project to distribute a complete environment. The OSGeo4W build is fully maintained by the QGIS project.
 
-OSGEO4W provides update scripts, allowing you to upgrade only the necessary libraries without the need to redownload the entire package. For more information on setting up these scripts for your deployment, refer to the [OSGEO4W documentation](https://trac.osgeo.org/osgeo4w/).
+OSGeo4W provides update scripts, allowing you to upgrade only the necessary libraries without the need to redownload the entire package. For more information on setting up these scripts for your deployment, refer to the [OSGeo4W documentation](https://trac.osgeo.org/osgeo4w/).
 
 
 On **[Ubuntu / Debian](/resources/installation-guide/#debian--ubuntu)**, we provide QGIS binaries and work closely with packagers of OSGEO libraries (GDAL / PROJ / GRASS).
@@ -92,7 +92,7 @@ Fixes are shipped as soon as possible in point releases - depending on the criti
 
 If you want to secure your QGIS enterprise deployment, please ensure you are  able to quickly deploy fixes to the machines you manage. 
 
-OSGEO4W provides update scripts that can run unattended. These scripts also  allow you to upgrade only the necessary libraries without the need to re-download the entire package. For more information on setting up these scripts for your deployment, refer to the [OSGEO4W documentation](https://trac.osgeo.org/osgeo4w/).
+OSGeo4W provides update scripts that can run unattended. These scripts also  allow you to upgrade only the necessary libraries without the need to re-download the entire package. For more information on setting up these scripts for your deployment, refer to the [OSGeo4W documentation](https://trac.osgeo.org/osgeo4w/).
 
 
 

--- a/playwright/ci-test/tests/06-resources-page.spec.ts
+++ b/playwright/ci-test/tests/06-resources-page.spec.ts
@@ -214,7 +214,6 @@ test.describe("Resources pages", () => {
         await expect(roadmapPage.osgeo4w).toBeVisible();
         await expect(roadmapPage.linux).toBeVisible();
         await expect(roadmapPage.debianUbuntu).toBeVisible();
-        await expect(roadmapPage.macOS).toBeVisible();
 
         for (const text of roadmapPage.textList) {
             await expect(roadmapPage.pageBody).toContainText(text);

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-platforms-start.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-platforms-start.html
@@ -18,8 +18,7 @@
                 We are currently in feature freeze preceeding the release of
                 QGIS {{ .nextversion }}.
                 <strong>Please consider testing the prereleases</strong>. See
-                <a
-                    href="{{ absURL "resources/roadmap#location-of-prereleases-nightly-builds" }}"
+                <a href="{{ absURL "resources/roadmap#qgis-prereleases" }}"
                     >road map</a
                 >.
             </p>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-windows.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-windows.html
@@ -1,55 +1,59 @@
 {{ with index .Site.Data.conf }}
+    <h2 class="title is-size-5">Online (OSGeo4W) installer:</h2>
 
-<h2 class="title is-size-5">Online (OSGeo4W) installer:</h2>
+    <a
+        class="button is-primary1 mb-3"
+        href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe"
+        onclick="thanks(this)"
+        download
+        >OSGeo4W Network Installer</a
+    >
+    <br />
+    <p>
+        This installer is the best way to keep QGIS up to date, run multiple
+        versions on your system and keep the load on our download servers to a
+        minimum.
+        <a
+            href="{{ absURL "resources/installation-guide#online-osgeo4w-installer" }}"
+        >
+            Learn more.
+        </a>
+    </p>
 
-<a
-	class="button is-primary1 mb-3"
-	href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe"
-    onclick="thanks(this)"
-    download
->OSGeo4W Network Installer</a>
-<br>
-<p>
-    This installer is the best way to keep QGIS up to date, 
-    run multiple versions on your system and keep the load 
-    on our download servers to a minimum. 
-    <a href="{{ absURL "resources/installation-guide#osgeo4w-installer" }}">
-        Learn more.
-    </a>
-</p>
+    <h2 class="title is-size-5">Offline (Standalone) installers:</h2>
+    <a
+        class="button is-primary1 mb-3"
+        href="{{ .ltr_msi }}"
+        onclick="thanks(this)"
+        download
+        >Long Term Version for Windows ({{ .ltrversion }} {{ .ltrnote }})</a
+    >
 
-<h2 class="title is-size-5">Offline (Standalone) installers:</h2>
-<a
-	class="button is-primary1 mb-3"
-	href="{{ .ltr_msi }}"
-    onclick="thanks(this)"
-    download
->Long Term Version for Windows ({{ .ltrversion }} {{ .ltrnote }})</a>
+    <a
+        class="button is-primary1 is-outlined mb-3"
+        href="{{ .lr_msi }}"
+        onclick="thanks(this)"
+        download
+        >Latest Version for Windows ({{ .version }})</a
+    >
 
-<a
-	class="button is-primary1 is-outlined mb-3"
-	href="{{ .lr_msi }}"
-    onclick="thanks(this)"
-    download
->Latest Version for Windows ({{ .version }})</a>
+    <a
+        class="button is-primary1 is-outlined mb-3"
+        href="{{ .lr_qt6_msi }}"
+        onclick="thanks(this)"
+        download
+        >Latest Version for Windows ({{ .version }}) with Qt6 (experimental)</a
+    >
 
-<a
-	class="button is-primary1 is-outlined mb-3"
-	href="{{ .lr_qt6_msi }}"
-    onclick="thanks(this)"
-    download
->Latest Version for Windows ({{ .version }}) with Qt6 (experimental)</a>
+    <p>
+        These installers are for users who wish to easily share the download
+        e.g. putting it on a USB key or network share.
+        <a
+            href="{{ absURL "resources/installation-guide#offline-standalone-installers" }}"
+        >
+            Learn more.
+        </a>
+    </p>
 
-<p>
-    These installers are for users who wish 
-    to easily share the download e.g. putting 
-    it on a USB key or network share.
-    <a href="{{ absURL "resources/installation-guide#standalone-installers" }}">
-        Learn more.
-    </a>
-</p>
-
-<p>
-    ⚠️ Since QGIS 3.20 we only ship 64-bit Windows executables.
-</p>
+    <p>⚠️ Since QGIS 3.20 we only ship 64-bit Windows executables.</p>
 {{ end }}

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-windows.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-windows.html
@@ -1,59 +1,55 @@
 {{ with index .Site.Data.conf }}
-    <h2 class="title is-size-5">Online (OSGeo4W) installer:</h2>
 
-    <a
-        class="button is-primary1 mb-3"
-        href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe"
-        onclick="thanks(this)"
-        download
-        >OSGeo4W Network Installer</a
-    >
-    <br />
-    <p>
-        This installer is the best way to keep QGIS up to date, run multiple
-        versions on your system and keep the load on our download servers to a
-        minimum.
-        <a
-            href="{{ absURL "resources/installation-guide#online-osgeo4w-installer" }}"
-        >
-            Learn more.
-        </a>
-    </p>
+<h2 class="title is-size-5">Online (OSGeo4W) installer:</h2>
 
-    <h2 class="title is-size-5">Offline (Standalone) installers:</h2>
-    <a
-        class="button is-primary1 mb-3"
-        href="{{ .ltr_msi }}"
-        onclick="thanks(this)"
-        download
-        >Long Term Version for Windows ({{ .ltrversion }} {{ .ltrnote }})</a
-    >
+<a
+	class="button is-primary1 mb-3"
+	href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe"
+    onclick="thanks(this)"
+    download
+>OSGeo4W Network Installer</a>
+<br>
+<p>
+    This installer is the best way to keep QGIS up to date, 
+    run multiple versions on your system and keep the load 
+    on our download servers to a minimum. 
+    <a href="{{ absURL "resources/installation-guide#online-osgeo4w-installer" }}">
+        Learn more.
+    </a>
+</p>
 
-    <a
-        class="button is-primary1 is-outlined mb-3"
-        href="{{ .lr_msi }}"
-        onclick="thanks(this)"
-        download
-        >Latest Version for Windows ({{ .version }})</a
-    >
+<h2 class="title is-size-5">Offline (Standalone) installers:</h2>
+<a
+	class="button is-primary1 mb-3"
+	href="{{ .ltr_msi }}"
+    onclick="thanks(this)"
+    download
+>Long Term Version for Windows ({{ .ltrversion }} {{ .ltrnote }})</a>
 
-    <a
-        class="button is-primary1 is-outlined mb-3"
-        href="{{ .lr_qt6_msi }}"
-        onclick="thanks(this)"
-        download
-        >Latest Version for Windows ({{ .version }}) with Qt6 (experimental)</a
-    >
+<a
+	class="button is-primary1 is-outlined mb-3"
+	href="{{ .lr_msi }}"
+    onclick="thanks(this)"
+    download
+>Latest Version for Windows ({{ .version }})</a>
 
-    <p>
-        These installers are for users who wish to easily share the download
-        e.g. putting it on a USB key or network share.
-        <a
-            href="{{ absURL "resources/installation-guide#offline-standalone-installers" }}"
-        >
-            Learn more.
-        </a>
-    </p>
+<a
+	class="button is-primary1 is-outlined mb-3"
+	href="{{ .lr_qt6_msi }}"
+    onclick="thanks(this)"
+    download
+>Latest Version for Windows ({{ .version }}) with Qt6 (experimental)</a>
 
-    <p>⚠️ Since QGIS 3.20 we only ship 64-bit Windows executables.</p>
+<p>
+    These installers are for users who wish 
+    to easily share the download e.g. putting 
+    it on a USB key or network share.
+    <a href="{{ absURL "resources/installation-guide#offline-standalone-installers" }}">
+        Learn more.
+    </a>
+</p>
+
+<p>
+    ⚠️ Since QGIS 3.20 we only ship 64-bit Windows executables.
+</p>
 {{ end }}


### PR DESCRIPTION
Fix for #532 

- Fixed the links on the `Download QGIS for your platform`, the `Road Map` and the `Security` pages
- Replace OSGEO4W with OSGeo4W

In the Road Map page, macOS is listed in the prereleases / nightly builds table at https://qgis.org/resources/roadmap/#qgis-prereleases. However, I couldn't find any link to prereleases / nightly builds for macOS (do they exist?) so I suggest hiding it for now. Any suggestions on that would be welcome.

![image](https://github.com/user-attachments/assets/27b1f571-1b18-4edc-b7da-681bfcb0f668)

On the security page, the text description at https://qgis.org/resources/support/security/#what-to-do-if-you-think-you-have-found-a-security-issue is a duplicate of the text at https://qgis.org/resources/support/#security-vulnerability-reporting.

So instead of:

> If you believe you have found a security issue, such as vulnerabilities in QGIS or its dependencies, please refer to the [security page](https://qgis.org/resources/support/security/) for detailed information on how to report it responsibly. Before this, please do the following:

I suggest the following text on the actual security page (https://qgis.org/resources/support/security/):

> If you believe you have found a security issue, such as vulnerabilities in QGIS or its dependencies, please do the following:

![image](https://github.com/user-attachments/assets/00501080-7c6c-4c32-a4ad-762483643857)
