### PR TITLE
Add a redirect from the old URL

### DIFF
--- a/content/community/organisation/meetings/uc-2025.html
+++ b/content/community/organisation/meetings/uc-2025.html
@@ -1,0 +1,13 @@
+---
+type: "page"
+title: "QGIS User Conference 2025"
+draft: false
+aliases:
+  - /uc-2025
+---
+
+<meta http-equiv="refresh" content="0; url=https://uc2025.qgis.org/" />
+
+You will be redirected to the conference page in a moment.
+
+If you are not redirected, please click <a href="https://uc2025.qgis.org/">here</a>.


### PR DESCRIPTION
Forgot that there are several places linking to qgis.org/uc-2025 now so we'd like to have a redirect. This is sort of hacky but does the trick, and will not be needed for future conferences where the subdomain site is used from the start.