### PR TITLE
Add links to QGIS Hub and QGIS Planet

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -174,10 +174,21 @@ sectionPagesMenu = 'main'
 
 [[menu.main]]
   parent = "Project"
-  name = "Visual Changelogs"
-  url = "/project/visual-changelogs"
+  name = "All News"
+  url = "https://feed.qgis.org"
   weight = 40
 
+[[menu.main]]
+  parent = "Project"
+  name = "Visual Changelogs"
+  url = "/project/visual-changelogs"
+  weight = 50
+
+[[menu.main]]
+  parent = "Project"
+  name = "QGIS Metrics"
+  url = "https://analytics.qgis.org"
+  weight = 60
 
 [[menu.main]]
   name = "Community"
@@ -299,7 +310,7 @@ sectionPagesMenu = 'main'
 [[menu.main]]
   parent = "Community"
   name = "Members Blogs"
-  url = "https://plugins.qgis.org/planet/"
+  url = "https://planet.qgis.org"
   weight = 280
 
 [[menu.main]]
@@ -523,6 +534,12 @@ sectionPagesMenu = 'main'
   weight = 50
 
 [[menu.main]]
+  parent = "Resources"
+  name = "Resources Hub"
+  url = "https://hub.qgis.org"
+  weight = 55
+
+[[menu.main]]
   parent = "Reports"
   name = "OGC Certification"
   url = "/resources/reports/#ogc-certification"
@@ -590,21 +607,9 @@ sectionPagesMenu = 'main'
 
 [[menu.main]]
   parent = "Resources"
-  name = "QGIS Metrics"
-  url = "https://analytics.qgis.org"
-  weight = 180
-
-[[menu.main]]
-  parent = "Resources"
-  name = "Plugins Metrics"
-  url = "https://plugins.qgis.org/metabase/public/dashboard/7ecd345f-7321-423d-9844-71e526a454a9"
-  weight = 190
-
-[[menu.main]]
-  parent = "Resources"
   name = "Blog"
   url = "https://blog.qgis.org/"
-  weight = 200
+  weight = 180
 
 [[menu.main]]
   parent = "Contact and Support"

--- a/content/resources/support/bug-reporting.md
+++ b/content/resources/support/bug-reporting.md
@@ -23,7 +23,9 @@ Each part of the QGIS Project has a dedicated place where issues (feature reques
 |QGIS Documentation (https://docs.qgis.org)|https://github.com/qgis/QGIS-Documentation/issues|
 |C++ API (https://qgis.org/api)|https://github.com/qgis/QGIS/issues|
 |PyQGIS API (https://qgis.org/pyqgis)|https://github.com/qgis/QGIS/issues (for contents) and https://github.com/qgis/pyqgis/issues (for formatting)|
-|QGIS Plugins Website (https://plugins.qgis.org)|https://github.com/qgis/QGIS-Django/issues|
+|QGIS Plugins Website (https://plugins.qgis.org)|https://github.com/qgis/QGIS-Plugins-Website/issues|
+|QGIS Hub Website (https://hub.qgis.org)|https://github.com/qgis/QGIS-Hub-Website/issues|
+|QGIS Planet Website (https://planet.qgis.org)|https://github.com/qgis/QGIS-Planet-Website/issues|
 |QGIS Changelog Website (https://changelog.qgis.org)|https://github.com/kartoza/prj.app/issues|
 |QGIS Feed Website (https://feed.qgis.org)|https://github.com/qgis/qgis-feed/issues|
 |External plugins|The author repository set in the plugin description|

--- a/fetch_feeds.py
+++ b/fetch_feeds.py
@@ -236,14 +236,14 @@ try:
 except Exception as e:
     print(f"Error fetching flickr screenshots: {e}")
 
-try:
-    # Planet blog aggregator
-    fetch_blog_feed(
-        showcase_type="planet",
-        rss_url="https://plugins.qgis.org/planet/feed/atom/"
-    )
-except Exception as e:
-    print(f"Error fetching planet blog feed: {e}")
+# try:
+#     # Planet blog aggregator
+#     fetch_blog_feed(
+#         showcase_type="planet",
+#         rss_url="https://plugins.qgis.org/planet/feed/atom/"
+#     )
+# except Exception as e:
+#     print(f"Error fetching planet blog feed: {e}")
 
 try:
     # QGIS User group feed

--- a/playwright/ci-test/tests/01-home-page.spec.ts
+++ b/playwright/ci-test/tests/01-home-page.spec.ts
@@ -117,7 +117,6 @@ test.describe("Home page", () => {
         await expect(footer.booksLink).toBeVisible();
         await expect(footer.supportLink).toBeVisible();
         await expect(footer.qgisDashboardLink).toBeVisible();
-        await expect(footer.pluginsDashboardLink).toBeVisible();
         await expect(footer.blogLink).toBeVisible();
         await expect(footer.donateLink).toBeVisible();
         await expect(footer.membershipList).toBeVisible();

--- a/playwright/ci-test/tests/fixtures/footer.ts
+++ b/playwright/ci-test/tests/fixtures/footer.ts
@@ -26,7 +26,7 @@ export class Footer {
     public readonly booksLink: Locator;
     public readonly supportLink: Locator;
     public readonly qgisDashboardLink: Locator;
-    public readonly pluginsDashboardLink: Locator;
+    public readonly resourcesHubLink: Locator;
     public readonly blogLink: Locator;
     public readonly donateLink: Locator;
     public readonly membershipList: Locator;
@@ -46,7 +46,9 @@ export class Footer {
     constructor(public readonly page: Page) {
         this.banner = this.page.getByRole("contentinfo");
         this.liElement = this.page.locator("li");
-        this.projectList = this.liElement.filter({ hasText: "Project"}).first();
+        this.projectList = this.liElement
+            .filter({ hasText: "Project" })
+            .first();
         this.communityList = this.liElement.filter({ hasText: "Community" });
         this.resourcesList = this.liElement.filter({ hasText: "Resources" });
         this.fundingList = this.liElement.filter({ hasText: "Funding" });
@@ -58,17 +60,22 @@ export class Footer {
         this.caseStudiesLink = this.banner.getByRole("link", {
             name: "Case studies",
         });
-        this.pluginsLink = this.banner.getByRole("link", { name: "Plugins", exact: true });
+        this.pluginsLink = this.banner.getByRole("link", {
+            name: "Plugins",
+            exact: true,
+        });
         this.visualChangelogsLink = this.banner.getByRole("link", {
             name: "Visual Changelogs",
         });
         this.getInvolvedLink = this.banner.getByRole("link", {
             name: "Get involved",
         });
-        this.becomeCertifiedMemberLink = this.page.getByRole("link", {
-            name: "Certification Programme",
-            exact: true,
-        }).first();
+        this.becomeCertifiedMemberLink = this.page
+            .getByRole("link", {
+                name: "Certification Programme",
+                exact: true,
+            })
+            .first();
         this.qgisFoundationLink = this.banner.getByRole("link", {
             name: "QGIS Foundation",
         });
@@ -81,10 +88,12 @@ export class Footer {
         this.membersBlogsList = this.liElement.filter({
             hasText: "Members Blogs",
         });
-        this.documentationLink = this.page.getByRole("link", {
-            name: "Documentation",
-            exact: true,
-        }).first();
+        this.documentationLink = this.page
+            .getByRole("link", {
+                name: "Documentation",
+                exact: true,
+            })
+            .first();
         this.installationGuideLink = this.liElement.filter({
             hasText: "Installation guide",
         });
@@ -96,8 +105,8 @@ export class Footer {
             name: "QGIS Metrics",
             exact: true,
         });
-        this.pluginsDashboardLink = this.banner.getByRole("link", {
-            name: "Plugins Metrics",
+        this.resourcesHubLink = this.banner.getByRole("link", {
+            name: "Resources Hub",
             exact: true,
         });
         this.blogLink = this.banner.getByRole("link", {
@@ -119,8 +128,13 @@ export class Footer {
         this.visualStyleGuideLink = this.page.getByRole("link", {
             name: "Visual Style Guide",
         });
-        this.goodiesLink = this.page.getByRole("link", { name: "Goodies", exact: true });
-        this.archiveLink = this.page.getByRole("link", { name: "Archive" }).last();
+        this.goodiesLink = this.page.getByRole("link", {
+            name: "Goodies",
+            exact: true,
+        });
+        this.archiveLink = this.page
+            .getByRole("link", { name: "Archive" })
+            .last();
         this.logoImage = this.page.getByRole("img", { name: "Logo" });
         this.facebookLink = this.page.getByRole("link", { name: "" });
         this.youtubeLink = this.page.getByRole("link", { name: "" });

--- a/themes/hugo-bulma-blocks-theme/exampleSite/fetch_feeds.py
+++ b/themes/hugo-bulma-blocks-theme/exampleSite/fetch_feeds.py
@@ -193,10 +193,10 @@ if args.flickr:
     )
 
 # Planet blog aggregator
-fetch_blog_feed(
-    showcase_type="planet",
-    rss_url="https://plugins.qgis.org/planet/feed/atom/"
-)
+# fetch_blog_feed(
+#     showcase_type="planet",
+#     rss_url="https://plugins.qgis.org/planet/feed/atom/"
+# )
 # QGIS User group feed
 fetch_blog_feed(
     showcase_type="qug",


### PR DESCRIPTION
Fix for #549 

## Changes summary

- Add the hub link to the navigation bar: please see https://github.com/qgis/qgis-uni-navigation/pull/21
- Update the Report Bug page

![image](https://github.com/user-attachments/assets/d2af1ea7-6be3-43cd-b309-5eb054b4a462)


To be more accurate and also to limit the number of items in the resources menu, I've:
- Removed the Plugins Metrics link, it should be on the plugins' website instead
- Move the QGIS Metrics link to the Project menu

![image](https://github.com/user-attachments/assets/22495bed-3444-4728-a917-df7e7caecd58)

