### PR TITLE
Harvest maps from QGIS Hub

### DIFF
--- a/.github/workflows/update-feeds.yml
+++ b/.github/workflows/update-feeds.yml
@@ -37,6 +37,11 @@ jobs:
         pipenv run pip freeze
         pipenv run ./fetch_feeds.py
 
+    - name: '⚙️ Update Hub Maps'
+      run: |
+        cd ./qgis-website
+        pipenv run ./scripts/hub_maps_harvest.py
+
     - name: '✉️ Commit'
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/content/hub-maps/index.md
+++ b/content/hub-maps/index.md
@@ -1,0 +1,1 @@
+headless = true

--- a/content/project/overview.md
+++ b/content/project/overview.md
@@ -218,7 +218,7 @@ Demonstrations of our user's creativity, showcasing the powerful map creation ca
 {{< column-end >}}
 
 {{< column-start class="is-flex-direction-column is-two-thirds">}}
-{{< flickr-images showcase="map" quantity="5" columns="gallery" >}}
+{{< hub-maps showcase="map" quantity="5" columns="gallery" >}}
 
 {{< column-end >}}
 {{< columns-end >}}

--- a/content/project/overview/maps.md
+++ b/content/project/overview/maps.md
@@ -1,14 +1,13 @@
 ---
 type: "page"
 title: "QGIS Maps"
+description: "Amazing maps created using QGIS"
 draft: false
 HasBanner: false
 sidebar: true
 ---
 {{< content-start  >}}
-# QGIS Maps
-
-Amazing maps created using QGIS
+{{< maps-header>}}
 
 {{< flickr-images showcase="map" columns="gallery" >}}
 {{< content-end  >}}

--- a/content/project/overview/maps.md
+++ b/content/project/overview/maps.md
@@ -9,5 +9,5 @@ sidebar: true
 {{< content-start  >}}
 {{< maps-header>}}
 
-{{< flickr-images showcase="map" columns="gallery" >}}
+{{< hub-maps showcase="map" columns="gallery" >}}
 {{< content-end  >}}

--- a/scripts/hub_maps_harvest.py
+++ b/scripts/hub_maps_harvest.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import requests
+import shutil
+from urllib.parse import urlparse
+
+class MapHarvester:
+  def __init__(self, api_url, output_dir):
+    self.api_url = api_url
+    self.output_dir = output_dir
+    os.makedirs(self.output_dir, exist_ok=True)
+  
+  def clean_output_dir(self):
+    for filename in os.listdir(self.output_dir):
+      if filename == "index.md":
+        continue
+      file_path = os.path.join(self.output_dir, filename)
+      try:
+        if os.path.isfile(file_path) or os.path.islink(file_path):
+          os.unlink(file_path)
+        elif os.path.isdir(file_path):
+          shutil.rmtree(file_path)
+      except Exception as e:
+        print(f"Failed to delete {file_path}. Reason: {e}")
+
+  def fetch_maps(self):
+    response = requests.get(self.api_url)
+    response.raise_for_status()
+    data = response.json()
+
+    for map_item in data.get("results", []):
+      if map_item.get("is_publishable"):
+        self.process_map(map_item)
+
+  def process_map(self, map_item):
+    name = map_item["name"]
+    creator = map_item["creator"]
+    upload_date = map_item["upload_date"]
+    link = map_item["file"]
+    thumbnail_url = map_item["thumbnail"]
+    uuid = map_item["uuid"]
+
+    # Parse the thumbnail URL to get the file name
+    path = urlparse(thumbnail_url).path
+    image_ext = os.path.splitext(path)[1]
+    image_name = f"{uuid}{image_ext}"
+
+    # Download the thumbnail
+    image_path = os.path.join(self.output_dir, image_name)
+    self.download_file(thumbnail_url, image_path)
+
+    # Generate the markdown content
+    content = f"""---
+source: "hub"
+title: "{name}"
+creator: "{creator.strip()}"
+image: "{image_name}"
+date: "{upload_date}"
+link: "{link}"
+draft: "false"
+showcase: "map"
+---
+"""
+    # Write the markdown file
+    md_filename = os.path.join(self.output_dir, f"{uuid}.md")
+    with open(md_filename, "w", encoding="utf-8") as f:
+      f.write(content)
+      print(f"Markdown file created: {md_filename}")
+
+  def download_file(self, url, dest_path):
+    response = requests.get(url, stream=True)
+    response.raise_for_status()
+    with open(dest_path, "wb") as out_file:
+      shutil.copyfileobj(response.raw, out_file)
+    print(f"Downloaded: {dest_path}")
+
+if __name__ == "__main__":
+  API_URL = "http://hub.qgis.org/api/v1/resources/?resource_type=map"
+  OUTPUT_DIR = "content/hub-maps"
+
+  harvester = MapHarvester(api_url=API_URL, output_dir=OUTPUT_DIR)
+  harvester.clean_output_dir()
+  harvester.fetch_maps()

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/elements/content.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/elements/content.sass
@@ -172,6 +172,7 @@ $content-table-foot-cell-color: $text-strong !default
       transition: all 0.3s ease
       article
         min-height: 85%
+        width: fit-content
         figure
           background-color: unset !important
           height: unset !important
@@ -179,6 +180,8 @@ $content-table-foot-cell-color: $text-strong !default
         text-align: center
         color: #002033
         font-weight: 300
+        width: fit-content
+        gap: 1rem
       &:hover
         box-shadow: 0rem 0rem .75rem #ababab87
         border-color: #ffffff

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/elements/content.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/elements/content.sass
@@ -160,3 +160,25 @@ $content-table-foot-cell-color: $text-strong !default
     font-size: $size-medium
   &.is-large
     font-size: $size-large
+  
+  .maps-header
+    .add-map
+      background-color: #f5f5f5
+      border-radius: 10px
+      flex-direction: column
+      position: relative
+      width: 100%
+      height: fit-content
+      transition: all 0.3s ease
+      article
+        min-height: 85%
+        figure
+          background-color: unset !important
+          height: unset !important
+      a
+        text-align: center
+        color: #002033
+        font-weight: 300
+      &:hover
+        box-shadow: 0rem 0rem .75rem #ababab87
+        border-color: #ffffff

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/elements/gallery.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/elements/gallery.sass
@@ -3,6 +3,30 @@
     max-height: 250px
     overflow: hidden
     border-radius: 10px
+  .add-map
+    background-color: #f5f5f5
+    border-radius: 10px
+    flex-direction: column
+    position: relative
+    width: 100%
+    transition: all 0.3s ease
+    article
+      min-height: 85%
+      figure
+        background-color: unset !important
+        height: unset !important
+    a
+      text-align: center
+      color: #002033
+      font-weight: 300
+    &:hover
+      box-shadow: 0rem 0rem .75rem #ababab87
+      border-color: #ffffff
+  
+  .add-map-title  
+    display: block
+    width: 100%
+    text-align: center
 
   figure
     margin: auto

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/elements/gallery.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/elements/gallery.sass
@@ -3,31 +3,6 @@
     max-height: 250px
     overflow: hidden
     border-radius: 10px
-  .add-map
-    background-color: #f5f5f5
-    border-radius: 10px
-    flex-direction: column
-    position: relative
-    width: 100%
-    transition: all 0.3s ease
-    article
-      min-height: 85%
-      figure
-        background-color: unset !important
-        height: unset !important
-    a
-      text-align: center
-      color: #002033
-      font-weight: 300
-    &:hover
-      box-shadow: 0rem 0rem .75rem #ababab87
-      border-color: #ffffff
-  
-  .add-map-title  
-    display: block
-    width: 100%
-    text-align: center
-
   figure
     margin: auto
     border-radius: 10px

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/flickr-images.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/flickr-images.html
@@ -3,21 +3,6 @@
 {{ $columns := .Get "columns" | default "2" }}
 
         <div class="columns is-multiline gallery">
-
-            {{ if and (eq $showcaseType "map") (eq $quantity "100") }}
-                        <div class="column is-6 is-flex">
-                            <div class="add-map">
-                                <a href="https://github.com/qgis/QGIS-Website/issues/559" target="_blank">
-                                    <article class="tile is-child box is-transparent is-flex is-justify-content-center is-align-items-center pb-0">
-                                        <figure>
-                                            <img src="{{ absURL "img/addsupporter.svg" }}" loading="lazy" alt="add supporter">
-                                        </figure>
-                                    </article>
-                                    <span class="add-map-title mb-3">Add your map here?</span>
-                                </a>
-                            </div>
-                        </div>
-            {{ end }}
             {{ $.Scratch.Set "counter" 0 }}
             {{ $headlessbundle := .Site.GetPage "/flickr-images" }}
             {{ range where ( $headlessbundle.Resources.ByType "page" ) "Params.source" "flickr" }}
@@ -25,10 +10,8 @@
                 {{ $count := add ($.Scratch.Get "counter") 1 }}
                 {{ $.Scratch.Set "counter" $count }}
                 {{ $size := $columns }}  
-                {{ if and (eq $showcaseType "map") (eq $quantity "100") }}
-                    {{ $size = cond (ne $count 1 2 3) "4" "6" }}
-                {{ else }}
-                    {{ $size = cond (ne $count 1 2 6 7) "4" "6" }}
+                {{ if eq $columns "gallery" }}
+                     {{ $size = cond (ne $count 1 2 6 7) "4" "6" }} 
                 {{ end }}
                 {{ if le $count $quantity }}
                 <div class="column is-{{$size}} is-flex">{{/* is flex ensures cols have the same height */}}

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/flickr-images.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/flickr-images.html
@@ -3,6 +3,19 @@
 {{ $columns := .Get "columns" | default "2" }}
 
         <div class="columns is-multiline gallery">
+
+            <div class="column is-6 is-flex">
+                <div class="add-map">
+                    <a href="https://github.com/qgis/QGIS-Website/issues/559" target="_blank">
+                        <article class="tile is-child box is-transparent is-flex is-justify-content-center is-align-items-center pb-0">
+                            <figure>
+                                <img src="{{ absURL "img/addsupporter.svg" }}" loading="lazy" alt="add supporter">
+                            </figure>
+                        </article>
+                        <span class="add-map-title mb-3">Add your map here?</span>
+                    </a>
+                </div>
+            </div>
             {{ $.Scratch.Set "counter" 0 }}
             {{ $headlessbundle := .Site.GetPage "/flickr-images" }}
             {{ range where ( $headlessbundle.Resources.ByType "page" ) "Params.source" "flickr" }}
@@ -11,7 +24,7 @@
                 {{ $.Scratch.Set "counter" $count }}
                 {{ $size := $columns }}  
                 {{ if eq $columns "gallery" }}
-                    {{ $size = cond (ne $count 1 2 6 7) "4" "6" }}        
+                    {{ $size = cond (ne $count 1 2 3) "4" "6" }}        
                 {{ end }}
                 {{ if le $count $quantity }}
                 <div class="column is-{{$size}} is-flex">{{/* is flex ensures cols have the same height */}}

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/flickr-images.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/flickr-images.html
@@ -4,18 +4,20 @@
 
         <div class="columns is-multiline gallery">
 
-            <div class="column is-6 is-flex">
-                <div class="add-map">
-                    <a href="https://github.com/qgis/QGIS-Website/issues/559" target="_blank">
-                        <article class="tile is-child box is-transparent is-flex is-justify-content-center is-align-items-center pb-0">
-                            <figure>
-                                <img src="{{ absURL "img/addsupporter.svg" }}" loading="lazy" alt="add supporter">
-                            </figure>
-                        </article>
-                        <span class="add-map-title mb-3">Add your map here?</span>
-                    </a>
-                </div>
-            </div>
+            {{ if and (eq $showcaseType "map") (eq $quantity "100") }}
+                        <div class="column is-6 is-flex">
+                            <div class="add-map">
+                                <a href="https://github.com/qgis/QGIS-Website/issues/559" target="_blank">
+                                    <article class="tile is-child box is-transparent is-flex is-justify-content-center is-align-items-center pb-0">
+                                        <figure>
+                                            <img src="{{ absURL "img/addsupporter.svg" }}" loading="lazy" alt="add supporter">
+                                        </figure>
+                                    </article>
+                                    <span class="add-map-title mb-3">Add your map here?</span>
+                                </a>
+                            </div>
+                        </div>
+            {{ end }}
             {{ $.Scratch.Set "counter" 0 }}
             {{ $headlessbundle := .Site.GetPage "/flickr-images" }}
             {{ range where ( $headlessbundle.Resources.ByType "page" ) "Params.source" "flickr" }}
@@ -23,8 +25,10 @@
                 {{ $count := add ($.Scratch.Get "counter") 1 }}
                 {{ $.Scratch.Set "counter" $count }}
                 {{ $size := $columns }}  
-                {{ if eq $columns "gallery" }}
-                    {{ $size = cond (ne $count 1 2 3) "4" "6" }}        
+                {{ if and (eq $showcaseType "map") (eq $quantity "100") }}
+                    {{ $size = cond (ne $count 1 2 3) "4" "6" }}
+                {{ else }}
+                    {{ $size = cond (ne $count 1 2 6 7) "4" "6" }}
                 {{ end }}
                 {{ if le $count $quantity }}
                 <div class="column is-{{$size}} is-flex">{{/* is flex ensures cols have the same height */}}

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/hub-maps.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/hub-maps.html
@@ -1,0 +1,34 @@
+{{ $showcaseType := .Get "showcase" | default "" }}
+{{ $quantity := .Get "quantity" | default "100" }}
+{{ $columns := .Get "columns" | default "2" }}
+
+
+<div class="columns is-multiline gallery">
+    {{ $.Scratch.Set "counter" 0 }}
+    {{ $headlessbundle := .Site.GetPage "/hub-maps" }}
+    {{ range where ( $headlessbundle.Resources.ByType "page" ) "Params.source" "hub" }}
+        {{ if and (eq .Params.showcase $showcaseType) (eq .Params.draft false) }}
+            {{ $count := add ($.Scratch.Get "counter") 1 }}
+            {{ $.Scratch.Set "counter" $count }}
+            {{ $size := $columns }}
+            {{ if eq $columns "gallery" }}
+                {{ $size = cond (ne $count 1 2 6 7) "4" "6" }}
+            {{ end }}
+            {{ if le $count $quantity }}
+                <div class="column is-{{ $size }} is-flex">
+                    {{/* is flex ensures cols have the same height */}}
+                    <div class="imagetile">
+                        <figure>
+                            <a href="{{ .Params.link }}">
+                                <img
+                                    src="{{ .Site.BaseURL }}hub-maps/{{ .Params.image }}"
+                                    alt="{{ .Params.title }}"
+                                />
+                            </a>
+                        </figure>
+                    </div>
+                </div>
+            {{ end }}
+        {{ end }}
+    {{ end }}
+</div>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/maps-header.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/maps-header.html
@@ -9,15 +9,16 @@
         <p>{{ $description }}</p>
     </div>
     <div class="column is-6">
-        <div class="add-map p-3 is-flex">
+        <div class="add-map p-3 is-flex is-align-items-center">
             <a
                 href="https://github.com/qgis/QGIS-Website/issues/559"
                 target="_blank"
+                class="is-flex is-align-items-center"
             >
                 <article
                     class="tile is-child box is-transparent is-flex is-justify-content-center is-align-items-center p-0"
                 >
-                    <figure>
+                    <figure class="m-0">
                         <img
                             src="{{ absURL "img/addsupporter.svg" }}"
                             loading="lazy"

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/maps-header.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/maps-header.html
@@ -1,0 +1,32 @@
+{{ $title := .Page.Params.title | default "" }}
+{{ $description := .Page.Params.description | default "" }}
+<div class="columns is-multiline maps-header">
+    <div class="column is-6">
+        <h1 id="qgis-maps">
+            {{ $title }}
+            <a class="heading-anchor" href="#qgis-maps"> ¶ </a>
+        </h1>
+        <p>{{ $description }}</p>
+    </div>
+    <div class="column is-6">
+        <div class="add-map p-3 is-flex">
+            <a
+                href="https://github.com/qgis/QGIS-Website/issues/559"
+                target="_blank"
+            >
+                <article
+                    class="tile is-child box is-transparent is-flex is-justify-content-center is-align-items-center p-0"
+                >
+                    <figure>
+                        <img
+                            src="{{ absURL "img/addsupporter.svg" }}"
+                            loading="lazy"
+                            alt="add supporter"
+                        />
+                    </figure>
+                </article>
+                <span class="add-map-title">Add your map here!</span>
+            </a>
+        </div>
+    </div>
+</div>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/maps-header.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/maps-header.html
@@ -11,8 +11,7 @@
     <div class="column is-6">
         <div class="add-map p-3 is-flex is-align-items-center">
             <a
-                href="https://github.com/qgis/QGIS-Website/issues/559"
-                target="_blank"
+                href="https://hub.qgis.org/map-gallery/add/"
                 class="is-flex is-align-items-center"
             >
                 <article


### PR DESCRIPTION
Fix for #560 and #589

## Latest changes

- Added a button **Add your map here!** that goes to https://hub.qgis.org/map-gallery/add/
- Added a script to harvest publishable maps from https://maps.qgis.org. **Depends on https://github.com/qgis/QGIS-Hub-Website/pull/67**
- The harvest script will be part of the "Scrape and commit" (`update-feeds.yml`) workflow which runs every day at midnight & noon UTC
- Replace the maps from Flickr with the maps from the hub on the map showcase
- Only maps thumbnails (1024x1024) transformed to a `.webp` format are stored in the repo and shown on the map showcase
- Clicking on a map will show the map full size stored on the Hub

![image](https://github.com/user-attachments/assets/ade74524-c583-4a26-93ac-a363e8d57c4e)

![image](https://github.com/user-attachments/assets/3aad68a9-0f45-4b88-8c58-72ee206a6016)

