### PR TITLE
Resize images from the changelog website

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,9 @@ $ ./scripts/changelog_harvest.py
 
 # For a specific version
 $ ./scripts/changelog_harvest.py --version 3.34 --release 21.06.2024
+
+# Resizing the images for existing changelog
+$ ./scripts/changelog_harvest.py --version 3.34 --release 21.06.2024 --use_existing
 ```
 
 Example usage in md:

--- a/scripts/changelog_harvest.py
+++ b/scripts/changelog_harvest.py
@@ -22,55 +22,49 @@ import argparse
 import sys
 from zipfile import ZipFile
 from datetime import datetime
+from resize_image import resize_image, convert_to_webp, is_valid_image
 
-def download_and_extract_zip(version, release_date):
-    # Format version without special characters
-    version_formatted = re.sub(r'\D', '', version)
+class ChangelogHarvester:
+    def __init__(self, version=None, release_date=None):
+        self.version = version
+        self.release_date = release_date
+        self.version_formatted = re.sub(r'\D', '', self.version)
+        self.url = f'https://changelog.qgis.org/en/qgis/version/{self.version}/md/'
+        self.zip_filename = f'qgis_changelog_{self.version_formatted}.zip'
+        self.extract_path = f'content/project/visual-changelogs/visualchangelog{self.version_formatted}/'
 
-    # URL of the zip file
-    url = f'https://changelog.qgis.org/en/qgis/version/{version}/md/'
+    def download_and_extract_zip(self):
 
-    # Define file paths
-    zip_filename = f'qgis_changelog_{version_formatted}.zip'
-    extract_path = f'content/project/visual-changelogs/visualchangelog{version_formatted}'
+        print(f'Downloading {self.url}')
+        response = requests.get(self.url)
+        if response.status_code != 200:
+            print(f"Error: Could not download the file from {self.url}. HTTP status code: {response.status_code}")
+            return
 
-    # Download the zip file
-    print(f'Downloading {url}')
-    response = requests.get(url)
-    if response.status_code != 200:
-        print(f"Error: Could not download the file from {url}. HTTP status code: {response.status_code}")
-        return
+        with open(self.zip_filename, 'wb') as file:
+            file.write(response.content)
+        print(f'Downloaded {self.zip_filename}')
 
-    with open(zip_filename, 'wb') as file:
-        file.write(response.content)
-    print(f'Downloaded {zip_filename}')
+        print(f'Extracting {self.zip_filename} to {self.extract_path}')
+        with ZipFile(self.zip_filename, 'r') as zip_ref:
+            zip_ref.extractall(self.extract_path)
+        print(f'Extracted to {self.extract_path}')
 
-    # Extract the zip file
-    print(f'Extracting {zip_filename} to {extract_path}')
-    with ZipFile(zip_filename, 'r') as zip_ref:
-        zip_ref.extractall(extract_path)
-    print(f'Extracted to {extract_path}')
+        os.remove(self.zip_filename)
+        print(f'Removed {self.zip_filename}')
 
-    # Remove the zip file after extraction
-    os.remove(zip_filename)
-    print(f'Removed {zip_filename}')
+    def add_frontmatter_to_index(self):
+        index_file_path = os.path.join(self.extract_path, 'index.md')
+        print(f'Modifying {index_file_path}')
+        with open(index_file_path, 'r') as file:
+            content = file.read()
 
-    # Modify the index.md file
-    index_file_path = os.path.join(extract_path, 'index.md')
-    modify_index_file(index_file_path, version, version_formatted, release_date)
-
-def modify_index_file(index_file_path, version, version_formatted, release_date):
-    print(f'Modifying {index_file_path}')
-    with open(index_file_path, 'r') as file:
-        content = file.read()
-
-    # Add front matter
-    front_matter = f"""---
-title: "Changelog for QGIS {version}"
+        front_matter = f"""---
+title: "Changelog for QGIS {self.version}"
 draft: false
 HasBanner: false
 sidebar: true
-releaseDate: "{release_date}"
+releaseDate: "{self.release_date}"
 section: "project"
 type: "visual-changelog"
 
@@ -79,53 +73,79 @@ type: "visual-changelog"
 {{{{< content-start >}}}}
 
 """
-    content = front_matter + content
+        content = front_matter + content
+        content = re.sub(r'^(# .+)', r'\1 {#changelog' + self.version_formatted + '}', content, flags=re.M)
+        content = re.sub(r'(!\[.*?\]\(.*?\))', r'\1\n\nRelease date: ' + self.release_date, content, 1)
+        content += '\n\n{{< content-end >}}'
 
-    # Add id to the first heading
-    content = re.sub(r'^(# .+)', r'\1 {#changelog' + version_formatted + '}', content, flags=re.M)
+        with open(index_file_path, 'w') as file:
+            file.write(content)
+        print(f'Modified {index_file_path}')
 
-    # Insert release date after the first image
-    content = re.sub(r'(!\[.*?\]\(.*?\))', r'\1\n\nRelease date: ' + release_date, content, 1)
+    # Resize and Convert images in the index.md to webp format
+    def resize_and_convert_images(self):
+        index_file_path = os.path.join(self.extract_path, 'index.md')
+        print(f'Converting images in {index_file_path} to webp format')
 
-    # Append content-end
-    content += '\n\n{{< content-end >}}'
+        with open(index_file_path, 'r') as file:
+            content = file.read()
 
-    # Write the modified content back to the file
-    with open(index_file_path, 'w') as file:
-        file.write(content)
-    print(f'Modified {index_file_path}')
+        image_paths = re.findall(r'!\[.*?\]\((images/.*?)\)', content)
+        for image_path in image_paths:
+            full_image_path = os.path.join(self.extract_path, image_path)
+            
+            if is_valid_image(full_image_path):
+                resize_image(full_image_path, max_height=600)
+                webp_image_path = convert_to_webp(full_image_path, replace=True)
+                content = content.replace(
+                    image_path, 
+                    webp_image_path.replace(self.extract_path, '')
+                )
 
+        with open(index_file_path, 'w') as file:
+            file.write(content)
+        print(f'Converted images in {index_file_path} to webp format')
+        
 
-def load_config(config_path):
-    with open(config_path, 'r') as file:
-        config = json.load(file)
-    return config
+    @staticmethod
+    def load_config(config_path):
+        with open(config_path, 'r') as file:
+            config = json.load(file)
+        return config
 
-def format_release_date(date_str):
-    # Convert date from dd.mm.yyyy to yyyy-mm-dd
-    return datetime.strptime(date_str, "%d.%m.%Y").strftime("%Y-%m-%d")
+    @staticmethod
+    def format_release_date(date_str):
+        return datetime.strptime(date_str, "%d.%m.%Y").strftime("%Y-%m-%d")
 
-def parse_arguments():
-    parser = argparse.ArgumentParser(description="Download and extract QGIS changelog.")
-    parser.add_argument('--version', type=str, help="QGIS version (e.g., '3.34')")
-    parser.add_argument('--release', type=str, help="Release date in 'dd.mm.yyyy' format")
-    return parser.parse_args()
+    @staticmethod
+    def parse_arguments():
+        parser = argparse.ArgumentParser(description="Download and extract QGIS changelog.")
+        parser.add_argument('--version', type=str, help="QGIS version (e.g., '3.34')")
+        parser.add_argument('--release', type=str, help="Release date in 'dd.mm.yyyy' format")
+        parser.add_argument(
+            '--use_existing',
+            action='store_true',
+            help="Use existing files instead of downloading from the changelog site"
+        )
+        return parser.parse_args()
 
 if __name__ == '__main__':
-    # Parse command-line arguments
-    args = parse_arguments()
+    args = ChangelogHarvester.parse_arguments()
 
     if args.version and args.release:
         version = args.version
-        release_date = format_release_date(args.release)
+        release_date = ChangelogHarvester.format_release_date(args.release)
     elif not args.version and not args.release:
-        # Load configuration from JSON
         config_path = 'data/conf.json'
-        config = load_config(config_path)
+        config = ChangelogHarvester.load_config(config_path)
         version = config['version']
-        release_date = format_release_date(config['releasedate'])
+        release_date = config['releasedate']
     else:
         print("Error: You must specify both --version and --release, or neither.")
         sys.exit(1)
 
-    download_and_extract_zip(version, release_date)
+    harvester = ChangelogHarvester(version, release_date)
+    if not args.use_existing:
+        harvester.download_and_extract_zip()
+        harvester.add_frontmatter_to_index()
+    harvester.resize_and_convert_images()

--- a/scripts/changelog_harvest.py
+++ b/scripts/changelog_harvest.py
@@ -12,6 +12,10 @@ on the data at data/conf.json.
 To fetch changelogs for a specific version:
 
 $ python3 scripts/changelog_harvest.py --version 3.34 --release 21.06.2024
+
+# To trigger the images resize/transform process only for existing changelog
+$ ./scripts/changelog_harvest.py --version 3.34 --release 21.06.2024 --use_existing
+
 '''
 
 import os
@@ -26,6 +30,15 @@ from resize_image import resize_image, convert_to_webp, is_valid_image
 
 class ChangelogHarvester:
     def __init__(self, version=None, release_date=None):
+        """
+        Initialize the ChangelogHarvester object.
+        :param version: The QGIS version (e.g., '3.34')
+        :param release_date: The release date in 'dd.mm.yyyy' format
+        
+        If version and release_date are provided, they will be used.
+        Otherwise, the values from the config file will be used.
+        
+        """
         self.version = version
         self.release_date = release_date
         self.version_formatted = re.sub(r'\D', '', self.version)

--- a/scripts/resize_image.py
+++ b/scripts/resize_image.py
@@ -1,6 +1,8 @@
 from PIL import Image
 import os
+import xml.etree.ElementTree as ET
 
+SUPPORTED_FORMATS = ['png', 'jpg', 'jpeg', 'tiff']
 
 def resize_image(image_filename, max_height=120):
     """
@@ -9,37 +11,84 @@ def resize_image(image_filename, max_height=120):
     param image_filename: The image file to resize
     param max_height: The maximum height in pixels
     """
-    if (
-        image_filename.lower().endswith('.png') or
-        image_filename.lower().endswith('.jpg')
-    ):
+    if os.path.exists(image_filename):
+        with Image.open(image_filename) as img:
+
+            # Determine the file format
+            file_format = img.format
+            if not file_format or file_format.lower() not in SUPPORTED_FORMATS:
+                return
+            if file_format == 'JPG':
+                file_format = 'JPEG'
+            width, height = img.size
+            if height > max_height:
+                new_height = max_height
+                new_width = int((new_height / height) * width)
+
+                img_resized = img.resize(
+                    (new_width, new_height), Image.LANCZOS
+                )
+
+                # Save the resized image with optimization
+                img_resized.save(
+                    image_filename,
+                    format=file_format,
+                    optimize=True,
+                    quality=85
+                )
+    else:
+        print(f'File not found: {image_filename}')
+
+# Transform an image into webp format
+def convert_to_webp(image_filename, replace=False):
+    """
+    Convert an image to webp format.
+    The image is converted in place.
+    param image_filename: The image file to convert
+    """
+    with Image.open(image_filename) as img:
+        # Determine the file format
+        file_format = img.format
+        if file_format.lower() not in SUPPORTED_FORMATS:
+            return image_filename
         if os.path.exists(image_filename):
-            print(f'Processing: {image_filename}')
-            with Image.open(image_filename) as img:
-                width, height = img.size
-                if height > max_height:
-                    new_height = max_height
-                    new_width = int((new_height / height) * width)
-
-                    img_resized = img.resize(
-                        (new_width, new_height), Image.LANCZOS
-                    )
-
-                    # Determine the file format
-                    file_format = (
-                        'PNG' if image_filename.lower().endswith('.png')
-                        else 'JPEG'
-                    )
-
-                    # Save the resized image with optimization
-                    img_resized.save(
-                        image_filename,
-                        format=file_format,
-                        optimize=True,
-                        quality=85
-                    )
-                    print(f'Resized and optimized: {image_filename}')
-                else:
-                    print(f'No resizing needed for: {image_filename}')
+            # Save the image in webp format with optimization
+            webp_filename = image_filename + '.webp'
+            img.save(
+                webp_filename,
+                format='WEBP',
+                optimize=True,
+                quality=85
+            )
+            if replace:
+                os.remove(image_filename)
+            return webp_filename
         else:
             print(f'File not found: {image_filename}')
+            raise FileNotFoundError
+    
+# Check if the image is valid
+def is_valid_image(image_filename):
+    """
+    Check if the image file is valid.
+    param image_filename: The image file to check
+    return: True if the image is valid, False otherwise
+    """
+    try:
+        img = Image.open(image_filename)
+        img.verify()
+        return True
+    except Exception as e:
+        print(f'Invalid image: {image_filename}')
+
+def is_valid_svg(svg_filename):
+    """
+    Check if the svg file is valid.
+    param svg_filename: The svg file to check
+    return: True if the svg is valid, False otherwise
+    """
+    try:
+        ET.parse(svg_filename)  # Try to parse the XML
+        return True  # No error means it's valid
+    except ET.ParseError:
+        return False  # If parsing fails, it's invalid


### PR DESCRIPTION
Fix for #556 

Cc @timlinux @rduivenvoorde 

For each image used in the `index.md` from the changelog website, including the splash image:

- Check if the image is valid
- Resize it with a max height of 600px
- Transform it to `webp`
- Update the index.md to use the transformed image
- Possibility to run the resize the images of an existing changelog