### PR TITLE
GitHub sponsors

### DIFF
--- a/.github/workflows/update-gh-sponsors.yml
+++ b/.github/workflows/update-gh-sponsors.yml
@@ -1,0 +1,28 @@
+# This workflow updates the GitHub Sponsors list in the content/funding/donate/github-sponsors.md file.
+name: ❤️ Update the GitHub Sponsors page
+on:
+  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+  schedule:
+    - cron: '0 0,12 * * *'  # At midnight & noon UTC
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Generate Sponsors 💖
+        uses: JamesIves/github-sponsors-readme-action@v1
+        with:
+          token: ${{ secrets.PAT }}
+          file: 'content/funding/donate/github-sponsors.md'
+          organization: true
+    
+      - name: '✉️ Commit'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: 'GitHub Sponsors updated and committed via a GitHub Action.'
+          repository: ./qgis-website

--- a/.github/workflows/update-gh-sponsors.yml
+++ b/.github/workflows/update-gh-sponsors.yml
@@ -20,6 +20,12 @@ jobs:
           token: ${{ secrets.PAT }}
           file: 'content/funding/donate/github-sponsors.md'
           organization: true
+          active-only: false
+          template: |
+            <a class="rich-list third mr-2 mb-2" href="https://github.com/{{{ login }}}" target="_blank">
+              <div class="listcont external-link">{{{ name }}} - {{{ login }}}</div>
+              <div class="subtext is-size-7">https://github.com/{{{ login }}}</div>
+            </a>
     
       - name: '✉️ Commit'
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/update-gh-sponsors.yml
+++ b/.github/workflows/update-gh-sponsors.yml
@@ -1,5 +1,5 @@
 # This workflow updates the GitHub Sponsors list in the content/funding/donate/github-sponsors.md file.
-name: ❤️ Update the GitHub Sponsors page
+name: 💖 Update the GitHub Sponsors page and commit
 on:
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
   schedule:
@@ -11,10 +11,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎️
+      - name: '🛎️ Checkout'
         uses: actions/checkout@v3
 
-      - name: Generate Sponsors 💖
+      - name: '💖 Generate Sponsors'
         uses: JamesIves/github-sponsors-readme-action@v1
         with:
           token: ${{ secrets.PAT }}

--- a/config.toml
+++ b/config.toml
@@ -383,6 +383,12 @@ sectionPagesMenu = 'main'
   url = "/funding/donate/donors"
   weight = 270
 
+[[menu.main]]
+  parent = "Donate"
+  name = "GitHub Sponsors"
+  url = "/funding/donate/github-sponsors"
+  weight = 280
+
 # Submenus are done this way: parent -> identifier
 [[menu.main]]
   parent = "Resources"

--- a/content/funding/donate/github-sponsors.md
+++ b/content/funding/donate/github-sponsors.md
@@ -1,0 +1,15 @@
+---
+type: "page"
+title: "GitHub Sponsors"
+draft: false
+HasBanner: false
+sidebar: true
+---
+
+{{< content-start >}}
+
+# GitHub Sponsors
+
+<!-- sponsors --><!-- sponsors -->
+
+{{< content-end >}}

--- a/content/funding/donate/github-sponsors.md
+++ b/content/funding/donate/github-sponsors.md
@@ -12,6 +12,10 @@ sidebar: true
 
 Donations can be of any amount through [GitHub Sponsors](https://github.com/sponsors/qgis). Even a small contribution can make a difference and help us reach important project goals!
 
+<a class="rich-list third mr-2 mb-2" href="https://github.com/sponsors/qgis" target="_blank">
+    <div class="listcont external-link">Add you name here?</div>
+    <div class="subtext is-size-7">https://github.com/sponsors/qgis</div>
+</a>
 <!-- sponsors --><!-- sponsors -->
 
 {{< content-end >}}

--- a/content/funding/donate/github-sponsors.md
+++ b/content/funding/donate/github-sponsors.md
@@ -10,6 +10,8 @@ sidebar: true
 
 # GitHub Sponsors
 
+Donations can be of any amount through [GitHub Sponsors](https://github.com/sponsors/qgis). Even a small contribution can make a difference and help us reach important project goals!
+
 <!-- sponsors --><!-- sponsors -->
 
 {{< content-end >}}

--- a/content/funding/donate/github-sponsors.md
+++ b/content/funding/donate/github-sponsors.md
@@ -13,8 +13,8 @@ sidebar: true
 Donations can be of any amount through [GitHub Sponsors](https://github.com/sponsors/qgis). Even a small contribution can make a difference and help us reach important project goals!
 
 <a class="rich-list third mr-2 mb-2" href="https://github.com/sponsors/qgis" target="_blank">
-    <div class="listcont external-link">Add you name here?</div>
-    <div class="subtext is-size-7">https://github.com/sponsors/qgis</div>
+    <div class="listcont external-link">Want to see your name here?</div>
+    <div class="subtext is-size-7">Become a sponsor to QGIS on GitHub</div>
 </a>
 <!-- sponsors --><!-- sponsors -->
 


### PR DESCRIPTION
Fix for #551 

- Added a new page to list the GitHub sponsors
- Added a new workflow to update the GH sponsors' page using https://github.com/JamesIves/github-sponsors-readme-action
- The workflow will be triggered every day at midnight & noon UTC but can also be triggered manually from the Actions tab.
- The workflow will automatically commit the scrapped data (like the donors scrapping workflow).

**NOTE**: The current changes were not tested from my side as I don't have any available data to test with. I will submit additional fixes if needed.

![image](https://github.com/user-attachments/assets/deea75e5-90a8-4e71-9f95-0f7b8096fb17)
