### PR TITLE
Fix for sustaining members condition

### DIFF
--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/fund.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/fund.html
@@ -20,7 +20,8 @@
 
     {{ $funders := slice }}
     {{ range where $allFunders "Params.level" "Flagship" }}
-        {{ if or (eq $type "changelog") (ge (time .Params.endDate) now) }}
+        {{ $yesterday := now.AddDate 0 0 -1 }}
+        {{ if or (eq $type "changelog") (ge (time .Params.endDate) $yesterday) }}
             {{ $funders = $funders | append . }}
         {{ end }}
     {{ end }}
@@ -59,7 +60,8 @@
 
     {{ $funders := slice }}
     {{ range where $allFunders "Params.level" "Large" }}
-        {{ if or (eq $type "changelog") (ge (time .Params.endDate) now) }}
+        {{ $yesterday := now.AddDate 0 0 -1 }}
+        {{ if or (eq $type "changelog") (ge (time .Params.endDate) $yesterday) }}
             {{ $funders = $funders | append . }}
         {{ end }}
     {{ end }}
@@ -99,7 +101,8 @@
 
     {{ $funders := slice }}
     {{ range where $allFunders "Params.level" "Medium" }}
-        {{ if or (eq $type "changelog") (ge (time .Params.endDate) now) }}
+        {{ $yesterday := now.AddDate 0 0 -1 }}
+        {{ if or (eq $type "changelog") (ge (time .Params.endDate) $yesterday) }}
             {{ $funders = $funders | append . }}
         {{ end }}
     {{ end }}
@@ -140,7 +143,8 @@
 
     {{ $funders := slice }}
     {{ range where $allFunders "Params.level" "Small" }}
-        {{ if or (eq $type "changelog") (ge (time .Params.endDate) now) }}
+        {{ $yesterday := now.AddDate 0 0 -1 }}
+        {{ if or (eq $type "changelog") (ge (time .Params.endDate) $yesterday) }}
             {{ $funders = $funders | append . }}
         {{ end }}
     {{ end }}


### PR DESCRIPTION
This pull request includes updates to the `fund.html` shortcode in the `hugo-bulma-blocks-theme` to adjust the date comparison logic for funders. The changes ensure that funders whose end date is today are still included.

Each sustaining member’s end date is formatted as “2025-02-28”. However, when compared using the Hugo template, it’s translated to “2025-02-28 00:00”. A quick fix would be to use yesterday’s date for the comparison.

We need to update the script that scrapes the changelog to include the time (23:59) in the end date for a long-term fix.