### PR TITLE
Shorten text in annual report box

### DIFF
--- a/content/community/foundation/annual_reports.md
+++ b/content/community/foundation/annual_reports.md
@@ -5,7 +5,7 @@ draft: false
 HasBanner: false
 heroImage: "img/involve.jpg"
 sidebar: true
-description: Starting in 2017, coincident with the establishment of a formal legal entity (Swiss “Verein”), we are publishing an annual report for the preceding year highlighting key activities within the QGIS project.
+description: We are publishing an annual report for the preceding year highlighting key activities within the QGIS project.
 
 ---
 


### PR DESCRIPTION
Currently, we have two repeating sections with contradicting dates in https://qgis.org/community/foundation/

![Screenshot_20250304_214346_Firefox](https://github.com/user-attachments/assets/98586aeb-a253-4636-bc5d-8258dac0e8bf)
