### PR TITLE
Add payment link update on donation frequency change

### DIFF
--- a/themes/hugo-bulma-blocks-theme/assets/js/donate.js
+++ b/themes/hugo-bulma-blocks-theme/assets/js/donate.js
@@ -21,6 +21,7 @@ function updateOptions(freq) {
   visible.forEach(option => option.style.display = "inline-block");
   // check first visible element
   document.getElementById(visible[0].getAttribute('for')).checked = true;
+  updatePaymentLink();
 }
 
 let radioButtons = document.getElementById('donate-stripe').querySelectorAll('input[name="amount"]');


### PR DESCRIPTION
Fix for #586 

This pull request includes a small change to the `themes/hugo-bulma-blocks-theme/assets/js/donate.js` file. The change ensures that the payment link is updated whenever the options are updated in the `updateOptions` function.

* [`themes/hugo-bulma-blocks-theme/assets/js/donate.js`](diffhunk://#diff-0c1f8d477e37ba6d10a12e62f4ba0d9189035a2fd5f99a872e9c9a47033baac5R24): Added a call to `updatePaymentLink()` within the `updateOptions` function to ensure the payment link is refreshed when the options are updated.