### PR TITLE
Add title and description to maps

### DIFF
--- a/content/hub-maps/09706721-a04b-4920-a869-328b73dac0e8.md
+++ b/content/hub-maps/09706721-a04b-4920-a869-328b73dac0e8.md
@@ -1,10 +1,12 @@
 ---
 source: "hub"
 title: "Aquatic invasive species portrait"
+description: "This 6 x 3 feet (this is a low resolution version) map was created (100%) in QGIS. It is a portrait of the aquatic invasive species in southern Quebec, Canada. It represents the different species present and the infected lakes. The map was made using open data from Government of Quebec and invasive species observations comming from different organizations. It was designed to be printed full scale and displayed in enviromental education events."
 creator: "Theriault"
 image: "09706721-a04b-4920-a869-328b73dac0e8.webp"
 date: "2025-04-04T14:35:37.571046"
 link: "https://hub.qgis.org/media/maps/2025/EEEA_200dpi.jpeg"
+hub_link: "https://hub.qgis.org/map-gallery/30"
 draft: "false"
 showcase: "map"
 ---

--- a/content/hub-maps/384537d0-d003-4c64-ba9e-da65d7229ff8.md
+++ b/content/hub-maps/384537d0-d003-4c64-ba9e-da65d7229ff8.md
@@ -1,10 +1,12 @@
 ---
 source: "hub"
 title: "Wood-carved map of Rotterdam"
+description: "First, I've created a polygon for the extent and filled it with a wood texture using Raster Image Fill. Then I've downloaded data from Overture Maps using the QGIS GeoParquet Downloader plugin and styled it with a white stroke and an inner shadow."
 creator: "Hans Kwast"
 image: "384537d0-d003-4c64-ba9e-da65d7229ff8.webp"
 date: "2025-03-23T13:04:24.951337"
 link: "https://hub.qgis.org/media/maps/2025/Rotterdam_from_wood.png"
+hub_link: "https://hub.qgis.org/map-gallery/20"
 draft: "false"
 showcase: "map"
 ---

--- a/content/hub-maps/81b4af5c-74ff-4dff-8d95-d894149d9e82.md
+++ b/content/hub-maps/81b4af5c-74ff-4dff-8d95-d894149d9e82.md
@@ -1,10 +1,12 @@
 ---
 source: "hub"
 title: "Saint Lucia 1:25000 South"
+description: "A topographical map of Saint Lucia. Uses data from the Government of Saint Lucia, Open Street Map. Hill shade and elevation datasets were generated from the contours by Kartoza. Map design and cartography by Kartoza. Shared with permission from Marcathian Alexander. This map has been edited for publishing in the QGIS gallery and does not represent an official cartographic product of the Government of Saint Lucia."
 creator: "Tim Sutton"
 image: "81b4af5c-74ff-4dff-8d95-d894149d9e82.webp"
 date: "2025-03-10T00:06:30.554389"
 link: "https://hub.qgis.org/media/maps/2025/SaintLucioaSouth.png"
+hub_link: "https://hub.qgis.org/map-gallery/4"
 draft: "false"
 showcase: "map"
 ---

--- a/content/hub-maps/8da5e29d-38b6-4be6-a508-3d3e39c8e906.md
+++ b/content/hub-maps/8da5e29d-38b6-4be6-a508-3d3e39c8e906.md
@@ -1,10 +1,12 @@
 ---
 source: "hub"
 title: "An REM of the Willamette River, OR"
+description: "This map was done for the 2024 #30DayMapChallenge\r\nIt shows the Willamette River between Corvallis and Salem Oregon. A Relative Elevation Model (REM) is also known as a height above river raster. The DEM is detrended to the baseline elevation of the river. I used the IDW method detailed by Dan Coe Carto: https://dancoecarto.com/creating-rems-in-qgis-the-idw-method"
 creator: "Kurt Menke"
 image: "8da5e29d-38b6-4be6-a508-3d3e39c8e906.webp"
 date: "2025-03-25T11:30:32.639574"
 link: "https://hub.qgis.org/media/maps/2025/Willamette_River_REM.jpg"
+hub_link: "https://hub.qgis.org/map-gallery/24"
 draft: "false"
 showcase: "map"
 ---

--- a/content/hub-maps/91dae3dc-44d7-48aa-88c0-5157cc4971e1.md
+++ b/content/hub-maps/91dae3dc-44d7-48aa-88c0-5157cc4971e1.md
@@ -1,10 +1,12 @@
 ---
 source: "hub"
 title: "Waterberg Biosphere Reserve, South Africa"
+description: "This map was created by Amy Burness (Kartoza), Colin Bleach and Richard Wadley (authors of Waterberg Echoes). Amy created the map completely in QGIS. The original is printed on A0 suitable for use at a roadside information display. The map depicts key focal points in the Waterberg Biosphere Reserve, South Africa. Credits to Kartoza (https://kartoza.com) and Waterberg Tourism.."
 creator: "Tim Sutton"
 image: "91dae3dc-44d7-48aa-88c0-5157cc4971e1.webp"
 date: "2025-03-07T22:07:22.902470"
 link: "https://hub.qgis.org/media/maps/2025/waterber-map-small.png"
+hub_link: "https://hub.qgis.org/map-gallery/1"
 draft: "false"
 showcase: "map"
 ---

--- a/content/hub-maps/ad0f968f-e468-4db1-bcbe-209e3522c827.md
+++ b/content/hub-maps/ad0f968f-e468-4db1-bcbe-209e3522c827.md
@@ -1,10 +1,12 @@
 ---
 source: "hub"
 title: "Mount Teide"
+description: "This map was created by converting terrain model to polygon contours."
 creator: "Saber Razmjooei"
 image: "ad0f968f-e468-4db1-bcbe-209e3522c827.webp"
 date: "2025-03-18T07:41:49.548038"
 link: "https://hub.qgis.org/media/maps/2025/output3.png"
+hub_link: "https://hub.qgis.org/map-gallery/11"
 draft: "false"
 showcase: "map"
 ---

--- a/content/hub-maps/c54cae07-a1ee-48e0-9be1-66cb341266e8.md
+++ b/content/hub-maps/c54cae07-a1ee-48e0-9be1-66cb341266e8.md
@@ -1,10 +1,12 @@
 ---
 source: "hub"
 title: "Hydrology of Africa"
+description: "The dataset was modified by override using an expression to divide the ORD_STRA column by 10, and classified according to number of inflow rivers. Colour ramp was inverted (if necessary) to have brighter blue colours for larger rivers and vice versa."
 creator: "Akanazu"
 image: "c54cae07-a1ee-48e0-9be1-66cb341266e8.webp"
 date: "2025-03-25T13:05:17.441848"
 link: "https://hub.qgis.org/media/maps/2025/Africa_hydro.png"
+hub_link: "https://hub.qgis.org/map-gallery/27"
 draft: "false"
 showcase: "map"
 ---

--- a/content/hub-maps/d7212278-ae2e-4522-a40c-de4e7641bba3.md
+++ b/content/hub-maps/d7212278-ae2e-4522-a40c-de4e7641bba3.md
@@ -1,10 +1,12 @@
 ---
 source: "hub"
 title: "Vintage map of Rotterdam"
+description: "To create the map, I've used the TopoTijdReis plugin in QGIS to explore some beautiful historic maps. I then sampled fill and line colours and patterns from a topographic map of 1948. Using the OpenStreetMap vector tile from MapTiler via the MapTiler plugin, I adjusted the colours of features with the samples using Symbol layer types Raster Image Fill, Raster Line and Raster Image Marker. Because a vector tile layer was used, I can create this map style for any place on earth with enough OpenStreetMap data!\r\nThe TopoTijdReis plugin is an amazing tool that lets you travel through time with historic topographic maps of the Netherlands in QGIS!"
 creator: "Hans Kwast"
 image: "d7212278-ae2e-4522-a40c-de4e7641bba3.webp"
 date: "2025-03-23T12:56:26.974060"
 link: "https://hub.qgis.org/media/maps/2025/Rotterdam_Vintage_Map.png"
+hub_link: "https://hub.qgis.org/map-gallery/19"
 draft: "false"
 showcase: "map"
 ---

--- a/content/hub-maps/e1c74225-5d7c-4b53-9930-b94d805e631b.md
+++ b/content/hub-maps/e1c74225-5d7c-4b53-9930-b94d805e631b.md
@@ -1,10 +1,12 @@
 ---
 source: "hub"
 title: "Saint Lucia Monochrome Map"
+description: "A monochrome map of the area around Castries, Saint Lucia. The map was made in QGIS and includes data from diverse sources including OpenStreetmap and contributors, the Government of Saint Lucia and data generated for the purposes of creating the map."
 creator: "Tim Sutton"
 image: "e1c74225-5d7c-4b53-9930-b94d805e631b.webp"
 date: "2025-03-07T23:33:19.756697"
 link: "https://hub.qgis.org/media/maps/2025/StLucia_Monochrome_Map_Small.png"
+hub_link: "https://hub.qgis.org/map-gallery/2"
 draft: "false"
 showcase: "map"
 ---

--- a/content/hub-maps/f47f070b-5aff-42b6-99a3-801e37bb82d8.md
+++ b/content/hub-maps/f47f070b-5aff-42b6-99a3-801e37bb82d8.md
@@ -1,10 +1,12 @@
 ---
 source: "hub"
 title: "Great Meteor Sea Mountain"
+description: "Map of the Great Meteor, a Sea Mountain with ~4000m high, nearby the Azores Island.\r\nThe Layout template is from the Layout Loader Plugin\r\n\r\nThe major exercise of this map was the ability to put bathymetic contours labels following a line from an helper layer called labels, instead of randomly place along the contours.\r\n\r\nThis was the expression used on the labels placement geometry generator.\r\n\r\n    coalesce(\r\n\taggregate(\r\n\t\t'labels', -- layer\r\n\t\t'collect', -- aggregate type\r\n\t\tintersection(\r\n\t\t\tbuffer($geometry,3000),\r\n\t\t\tgeometry(@parent)\r\n\t\t), -- Expression\r\n\t\tintersects(\r\n\t\t\t$geometry,\r\n\t\t\tgeometry(@parent)\r\n\t\t) -- Filter\r\n\t),\r\n\t$geometry\r\n    )\r\n\r\n\r\nData: GEBCO (https://www.gebco.net/data_and_products/gridded_bathymetry_data/)"
 creator: "Neto"
 image: "f47f070b-5aff-42b6-99a3-801e37bb82d8.webp"
 date: "2025-03-17T15:04:32.360935"
 link: "https://hub.qgis.org/media/maps/2025/great_meteor_seamounts_layout.png"
+hub_link: "https://hub.qgis.org/map-gallery/9"
 draft: "false"
 showcase: "map"
 ---

--- a/scripts/hub_maps_harvest.py
+++ b/scripts/hub_maps_harvest.py
@@ -5,6 +5,7 @@ import os
 import requests
 import shutil
 from urllib.parse import urlparse
+import json
 
 class MapHarvester:
   def __init__(self, api_url, output_dir):
@@ -40,7 +41,9 @@ class MapHarvester:
 
   def process_map(self, map_item):
     name = map_item["name"]
+    description = map_item["description"]
     creator = map_item["creator"]
+    map_id = map_item["id"]
     upload_date = map_item["upload_date"]
     link = map_item["file"]
     thumbnail_url = map_item["thumbnail"]
@@ -59,10 +62,12 @@ class MapHarvester:
     content = f"""---
 source: "hub"
 title: "{name}"
+description: {json.dumps(description.strip())}
 creator: "{creator.strip()}"
 image: "{image_name}"
 date: "{upload_date}"
 link: "{link}"
+hub_link: "https://hub.qgis.org/map-gallery/{map_id}"
 draft: "false"
 showcase: "map"
 ---

--- a/themes/hugo-bulma-blocks-theme/assets/sass/style.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/style.sass
@@ -143,3 +143,35 @@ code
     padding-top: 3rem
   .tabs li:not(.is-active) a
     text-shadow: 0 0 5px #002033
+
+.map-image-container
+  position: relative
+  display: inline-block
+
+  .tooltip
+    position: absolute
+    top: 0
+    width: 100%
+    height: 100%
+    max-height: 250px
+    background-color: rgba(0, 0, 0, 0.7)
+    padding: 10px
+    border-radius: 5px
+    opacity: 0
+    transition: opacity 0.3s ease
+    pointer-events: none
+    display: flex
+    flex-direction: column
+    justify-content: center
+    align-items: center
+
+    .title-text
+      color: white
+
+    .description-text
+      color: white
+
+  &:hover
+    .tooltip
+      opacity: 1
+      pointer-events: auto

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/hub-maps.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/hub-maps.html
@@ -19,12 +19,58 @@
                 <div class="column is-{{ $size }} is-flex">
                     {{/* is flex ensures cols have the same height */}}
                     <div class="imagetile">
-                        <figure>
-                            <a href="{{ .Params.link }}">
+                        <figure class="map-image-container">
+                            <a
+                                href="{{ .Params.link }}"
+                                target="_blank"
+                                class="is-flex is-flex-direction-column"
+                            >
                                 <img
                                     src="{{ .Site.BaseURL }}hub-maps/{{ .Params.image }}"
                                     alt="{{ .Params.title }}"
                                 />
+
+                                <div class="tooltip">
+                                    <p
+                                        class="has-text-white has-text-weight-semibold"
+                                    >
+                                        {{ .Params.title | truncate 30 }}
+                                    </p>
+                                    <p class="has-text-white">
+                                        {{ .Params.description | truncate 100 }}
+                                    </p>
+                                    <p class="has-text-white is-size-7">
+                                        Uploaded by:
+                                        {{ .Params.creator | default "Unknown" }}
+                                        on
+                                        {{ .Params.date.Format "02-01-2006" }}
+                                    </p>
+                                    <p class="buttons mt-3">
+                                        <a
+                                            class="button is-danger"
+                                            href="{{ .Params.hub_link }}"
+                                        >
+                                            <span class="icon">
+                                                <i
+                                                    class="fas fa-info-circle"
+                                                ></i>
+                                            </span>
+                                            <span>Details</span>
+                                        </a>
+                                        <a
+                                            class="button is-success"
+                                            target="_blank"
+                                            href="{{ .Params.link }}"
+                                        >
+                                            <span class="icon">
+                                                <i
+                                                    class="fas fa-magnifying-glass-plus"
+                                                ></i>
+                                            </span>
+                                            <span>View</span>
+                                        </a>
+                                    </p>
+                                </div>
                             </a>
                         </figure>
                     </div>


### PR DESCRIPTION
Fix for #597 

Add a tooltip when hovering over a map:
- Added title, description, uploaded by and uploaded date info
- Added the `Details` that point to the details page on hub.qgis.org
- Added the `View` button that will open the full map image in a new tab
- Update the harvest script to include the needed details

![image](https://github.com/user-attachments/assets/3e156d8b-8fe7-421a-b601-8f3abae3994b)
