### PR TITLE
Fix macOS typo on the download buttons

### DIFF
--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-macos.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-macos.html
@@ -4,12 +4,12 @@
     href="/downloads/macos/qgis-macos-ltr.dmg"
     onclick="thanks(this)"
     download
->Long Term Version for Mac OS</a>
+>Long Term Version for macOS</a>
 
 <a
     class="button is-primary1 is-outlined mb-3"
     href="/downloads/macos/qgis-macos-pr.dmg"
     onclick="thanks(this)"
     download
->Regular Version for Mac OS</a>
+>Regular Version for macOS</a>
 {{ end }}


### PR DESCRIPTION
Additional fix for #570 

Replace Mac OS with macOS.