### PR TITLE
Improve map gallery

### DIFF
--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/elements/gallery.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/elements/gallery.sass
@@ -24,3 +24,12 @@
         display: flex
         align-items: center
         justify-content: center
+  .tile
+    .image
+      .map-info
+        position: absolute
+        right: 0
+        height: 100%
+        padding: 10px
+        .button
+          box-shadow: 0 0 5px rgba(0, 0, 0, 0.25)

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/hub-maps.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/hub-maps.html
@@ -79,3 +79,11 @@
         {{ end }}
     {{ end }}
 </div>
+<div class="has-text-centered mt-4">
+    <a class="button is-success" href="https://maps.qgis.org">
+        <span class="icon">
+            <i class="fas fa-arrow-right"></i>
+        </span>
+        <span>See more</span>
+    </a>
+</div>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/hub-maps.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/hub-maps.html
@@ -16,63 +16,50 @@
                 {{ $size = cond (ne $count 1 2 6 7) "4" "6" }}
             {{ end }}
             {{ if le $count $quantity }}
-                <div class="column is-{{ $size }} is-flex">
+                <div
+                    class="column is-{{ $size }} is-flex"
+                    style="max-height: unset;"
+                >
                     {{/* is flex ensures cols have the same height */}}
-                    <div class="imagetile">
-                        <figure class="map-image-container">
-                            <a
-                                href="{{ .Params.link }}"
-                                target="_blank"
-                                class="is-flex is-flex-direction-column"
-                            >
+                    <div class="tile">
+                        <a
+                            class="rich-list has-image mr-2 mb-2"
+                            href="{{ .Params.hub_link }}"
+                        >
+                            <div class="image">
                                 <img
                                     src="{{ .Site.BaseURL }}hub-maps/{{ .Params.image }}"
-                                    alt="{{ .Params.title }}"
                                 />
-
-                                <div class="tooltip">
-                                    <p
-                                        class="has-text-white has-text-weight-semibold"
-                                    >
-                                        {{ .Params.title | truncate 30 }}
-                                    </p>
-                                    <p class="has-text-white">
-                                        {{ .Params.description | truncate 100 }}
-                                    </p>
-                                    <p class="has-text-white is-size-7">
-                                        Uploaded by:
-                                        {{ .Params.creator | default "Unknown" }}
-                                        on
-                                        {{ .Params.date.Format "02-01-2006" }}
-                                    </p>
-                                    <p class="buttons mt-3">
-                                        <a
-                                            class="button is-danger"
-                                            href="{{ .Params.hub_link }}"
+                                <div
+                                    class="map-info is-flex is-flex-direction-column is-justify-content-space-between is-align-items-flex-end"
+                                >
+                                    <div>
+                                        <button
+                                            class="button is-light"
+                                            onclick="event.preventDefault(); window.open('{{ .Params.link }}', '_blank');"
                                         >
-                                            <span class="icon">
-                                                <i
-                                                    class="fas fa-info-circle"
-                                                ></i>
-                                            </span>
-                                            <span>Details</span>
-                                        </a>
-                                        <a
-                                            class="button is-success"
-                                            target="_blank"
-                                            href="{{ .Params.link }}"
-                                        >
-                                            <span class="icon">
+                                            <span class="icon is-size-4">
                                                 <i
                                                     class="fas fa-magnifying-glass-plus"
                                                 ></i>
                                             </span>
-                                            <span>View</span>
-                                        </a>
-                                    </p>
+                                        </button>
+                                    </div>
+                                    <span class="tag is-light is-success">
+                                        Uploaded by
+                                        {{ .Params.creator | default "Unknown" }}
+                                    </span>
                                 </div>
-                            </a>
-                        </figure>
+                            </div>
+                            <div class="listcont ">
+                                <p class="has-text-weight-semibold">
+                                    {{ .Params.title | truncate 30 }}
+                                </p>
+                                <p>
+                                    {{ .Params.description | truncate 100 }}
+                                </p>
+                            </div>
+                        </a>
                     </div>
                 </div>
             {{ end }}


### PR DESCRIPTION
Fix for #610 and #611 

- Add "See more" button that redirects to the Hub map gallery (maps.qgis.org)
- Improve the map gallery to be mobile-friendly
- Clicking on a map will redirect to the map detail on the hub

![image](https://github.com/user-attachments/assets/63251a93-5213-4cf8-8a99-cebae96c6b39)

![image](https://github.com/user-attachments/assets/b8a513fc-a082-49d7-af2d-561f4c0fb82d)
