### PR TITLE
Bring stripe back and fix text in paypal donation

### DIFF
--- a/content/funding/donate.md
+++ b/content/funding/donate.md
@@ -41,17 +41,17 @@ We use the [payrexx.com](https://payrexx.com) service to receive credit card don
 {{< rich-box-end >}}
 
 
-<!-- {{< rich-box-start layoutClass="has-right mt-6" mode="html" >}}
+{{< rich-box-start layoutClass="has-right mt-6" mode="html" >}}
 {{< rich-content-start themeClass="coloring-1" >}}
 ## Stripe Donation
 
-We use the stripe.com service to receive credit card donations. Note that the payment fees at Stripe are substantially lower than at Paypal - so we would appreciate it, if you could use Stripe instead of PayPal. No signup needed.
+We also use the [stripe.com](https://stripe.com) service to receive credit card donations. Note that the payment fees at Stripe are substantially lower than at Paypal - so we would appreciate it, if you could use [Payrexx](#payrexx-donation) or Stripe instead of PayPal. No signup needed.
 {{< rich-content-end >}}
 {{< rich-right-start >}}  
 {{< stripe-widget >}}
 {{< rich-right-end >}}
 {{< rich-box-end >}}
- -->
+
 
 {{< rich-box-start layoutClass="has-right" mode="html" >}}
 {{< rich-content-start themeClass="coloring-1" >}}
@@ -82,7 +82,7 @@ VAT-number:   CHE-489.853.176
 {{< rich-content-start themeClass="coloring-1" >}}
 ## Paypal Donation
 
-You can use Paypal to donate using your own credit card (but we prefer to use Stripe for that). The payment is processed by PayPal but you don't need to have a PayPal account or sign-up for one if you are paying by credit card.
+You can use Paypal to donate using your own credit card (but we prefer to use [Payrexx](#payrexx-donation) for that). The payment is processed by PayPal but you don't need to have a PayPal account or sign-up for one if you are paying by credit card.
 
 You can also use your own Paypal account to donate.
 


### PR DESCRIPTION
Fix for #632 

- Payrexx is set as the default payment method on the download page, but users can choose Stripe and others when clicking on more options

![image](https://github.com/user-attachments/assets/fc82ef2b-b9f1-4289-b0f8-54777a882a27)


![image](https://github.com/user-attachments/assets/1b0987f4-5a89-4520-ae06-6a0ba9d3360c)

- Fix the description text for PayPal

![image](https://github.com/user-attachments/assets/a03efe8a-c1a3-4415-ac0c-2becd96435cc)
