### PR TITLE
QGIS FR for 2026

### DIFF
--- a/content/funders/qgis-fr.md
+++ b/content/funders/qgis-fr.md
@@ -2,8 +2,8 @@
 level: "Large"
 title: "QGIS user group France"
 logo: "qgis-fr.svg"
-startDate: "2024-03-01"
-endDate: "2025-02-28"
+startDate: "2025-03-01"
+endDate: "2026-02-28"
 link: "https://www.osgeo.fr/association/qgis-fr/"
 country: "France"
 ---


### PR DESCRIPTION
@andreasneumann I realize that QGIS-FR sponsorship disappeared from the website, probably because of our date mismatch this year.  QGIS-FR event was moved from winter to june, so we are some monthes late to renew the membership.
It will be held next week and we already are confident this will allow us to sponsor QGIS.org as a large member once again. 
Can we merge this so that we can show QGIS FR users involvment is useful ? 
I'm not sure about how you want to handle the dates.  I just incremented the year in the existing dates. 

cc @jmarsac 

Thanks ! 