### PR TITLE
Increase the animation duration of the progress bar

### DIFF
--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/utilities/initial-variables.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/utilities/initial-variables.sass
@@ -78,3 +78,6 @@ $speed: 86ms !default
 
 $variable-columns: true !default
 $rtl: false !default
+
+// Animation duration
+$progress-indeterminate-duration: 3.5s !default


### PR DESCRIPTION
Fix for #662 

Set the animation duration to 3.5 seconds (if not specified in the `initial-variable`, it will be set to 1.5 seconds by default).