### PR TITLE
Hide news when it expires, show a placeholder text if empty

### DIFF
--- a/data/feed.json
+++ b/data/feed.json
@@ -1,10 +1,1 @@
-{
-    "pk": 112,
-    "publish_from": 1750429200.0,
-    "publish_to": 1751325600.0,
-    "title": "Crowdfunding: QGIS 3D for Open Source Digital Twins",
-    "image": "https://feed.qgis.org/media/feedimages/2025/06/11/cf_dt.jpg",
-    "content": "<p>This crowdfunding campaign will improve and extend QGIS 3D capabilities, making it an ideal platform for digital twins. The project aims to add support for ESRI Scene Layers (I3S), support for more point cloud algorithms and enhanced vector support in 3D.</p>",
-    "url": "https://feed.qgis.org/112",
-    "sticky": false
-}
+{}

--- a/fetch_feeds.py
+++ b/fetch_feeds.py
@@ -140,16 +140,14 @@ def fetch_first_feed_entry():
     response = requests.get(feed_url)
     response.raise_for_status()
     feed_data = response.json()
-
+    entry = {}
     if feed_data and len(feed_data) > 0:
-        first_entry = feed_data[0]
-        first_entry['url'] = f"https://feed.qgis.org/{first_entry['pk']}"
-        os.makedirs(os.path.dirname(feed_file_path), exist_ok=True)
-        with open(feed_file_path, "w", encoding="utf-8") as f:
-            json.dump(first_entry, f, ensure_ascii=False, indent=4)
+        entry = feed_data[0]
+        entry['url'] = f"https://feed.qgis.org/{entry['pk']}"
         print(f"First feed entry saved to {feed_file_path}")
-    else:
-        print("No items found in the feed.")
+    os.makedirs(os.path.dirname(feed_file_path), exist_ok=True)
+    with open(feed_file_path, "w", encoding="utf-8") as f:
+        json.dump(entry, f, ensure_ascii=False, indent=4)
 
 
 parser = argparse.ArgumentParser(description='Import items from various feeds.')

--- a/themes/hugo-bulma-blocks-theme/layouts/partials/contextmenu.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/partials/contextmenu.html
@@ -7,7 +7,7 @@
             {{ .title }}
             </a>    
             {{ else }}
-            {{ errorf "Unable to get data from Site.data.feed" }}
+                <span class="is-italic" style="font-size: 14px;">Latest news will appear here soon.</span>
             {{ end }}
         </div>    
         <div id="search-control" class="control has-icons-right search-control">


### PR DESCRIPTION
Closes #690 

- Clean the news data file when https://feed.qgis.org/?lang=en&json=1 is empty (feed entry shouldn't be listed there anymore when it expires)
- Add the placeholder `Latest news will appear here soon.` when the news data file is empty

<img width="778" height="488" alt="image" src="https://github.com/user-attachments/assets/a658b8d5-0ad9-4e6c-9418-cffd0f4c3937" />
