### PR TITLE
Improve case studies page

### DIFF
--- a/content/project/case-studies-archive.md
+++ b/content/project/case-studies-archive.md
@@ -1,0 +1,17 @@
+---
+type: "page"
+title: "Archived Case Studies"
+draft: false
+HasBanner: false
+sidebar: true
+thumbnail: "/img/map2.png"
+
+---
+
+{{< content-start >}}
+
+# Archived Case Studies
+
+{{< usecases-archive >}}
+
+{{< content-end >}}

--- a/content/project/case-studies/afghanistan.md
+++ b/content/project/case-studies/afghanistan.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/afghanistan.md
+++ b/content/project/case-studies/afghanistan.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/afghanistan1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/afghanistan.md
+++ b/content/project/case-studies/afghanistan.md
@@ -7,6 +7,7 @@ thumbnail: "images/afghanistan1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/africa_tiger.md
+++ b/content/project/case-studies/africa_tiger.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/africa_tiger.md
+++ b/content/project/case-studies/africa_tiger.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/africa_tiger1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/africa_tiger.md
+++ b/content/project/case-studies/africa_tiger.md
@@ -7,6 +7,7 @@ thumbnail: "images/africa_tiger1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/antarctica.md
+++ b/content/project/case-studies/antarctica.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/antarctica.md
+++ b/content/project/case-studies/antarctica.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/quantarctica.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/antarctica.md
+++ b/content/project/case-studies/antarctica.md
@@ -7,6 +7,7 @@ thumbnail: "images/quantarctica.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/argentinia_chubut.md
+++ b/content/project/case-studies/argentinia_chubut.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/argentinia_chubut.md
+++ b/content/project/case-studies/argentinia_chubut.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/argentinia_chubut1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/argentinia_chubut.md
+++ b/content/project/case-studies/argentinia_chubut.md
@@ -7,6 +7,7 @@ thumbnail: "images/argentinia_chubut1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/australia_distance_learning.md
+++ b/content/project/case-studies/australia_distance_learning.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/australia_distance_learning.md
+++ b/content/project/case-studies/australia_distance_learning.md
@@ -7,6 +7,7 @@ thumbnail: "images/australia_distance_learning1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/australia_distance_learning.md
+++ b/content/project/case-studies/australia_distance_learning.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/australia_distance_learning1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/australia_queens.md
+++ b/content/project/case-studies/australia_queens.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/australia_queens.md
+++ b/content/project/case-studies/australia_queens.md
@@ -7,6 +7,7 @@ thumbnail: "images/australia_queens1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/australia_queens.md
+++ b/content/project/case-studies/australia_queens.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/australia_queens1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/australia_snowyhydro.md
+++ b/content/project/case-studies/australia_snowyhydro.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/australia_snowyhydro.md
+++ b/content/project/case-studies/australia_snowyhydro.md
@@ -7,6 +7,7 @@ thumbnail: "images/australia_snowyhydro1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/australia_snowyhydro.md
+++ b/content/project/case-studies/australia_snowyhydro.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/australia_snowyhydro1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/canada_brunswick.md
+++ b/content/project/case-studies/canada_brunswick.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/canada_brunswick.md
+++ b/content/project/case-studies/canada_brunswick.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/canada_brunswick1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/canada_brunswick.md
+++ b/content/project/case-studies/canada_brunswick.md
@@ -7,6 +7,7 @@ thumbnail: "images/canada_brunswick1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/china_hydro.md
+++ b/content/project/case-studies/china_hydro.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/china_hydro.md
+++ b/content/project/case-studies/china_hydro.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/china_hydro1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/china_hydro.md
+++ b/content/project/case-studies/china_hydro.md
@@ -7,6 +7,7 @@ thumbnail: "images/china_hydro1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/czech_brno.md
+++ b/content/project/case-studies/czech_brno.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/czech_brno.md
+++ b/content/project/case-studies/czech_brno.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/czech_brno1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/czech_brno.md
+++ b/content/project/case-studies/czech_brno.md
@@ -7,6 +7,7 @@ thumbnail: "images/czech_brno1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/europe_lynx.md
+++ b/content/project/case-studies/europe_lynx.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/europe_lynx.md
+++ b/content/project/case-studies/europe_lynx.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/europe_lynx1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/europe_lynx.md
+++ b/content/project/case-studies/europe_lynx.md
@@ -7,6 +7,7 @@ thumbnail: "images/europe_lynx1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/france_burgundy_region.md
+++ b/content/project/case-studies/france_burgundy_region.md
@@ -7,6 +7,7 @@ thumbnail: "images/france_burgundy.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/france_burgundy_region.md
+++ b/content/project/case-studies/france_burgundy_region.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/france_burgundy_region.md
+++ b/content/project/case-studies/france_burgundy_region.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/france_burgundy.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_assam.md
+++ b/content/project/case-studies/india_assam.md
@@ -7,6 +7,7 @@ thumbnail: "images/india_assam1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_assam.md
+++ b/content/project/case-studies/india_assam.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_assam.md
+++ b/content/project/case-studies/india_assam.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/india_assam1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_guwahati.md
+++ b/content/project/case-studies/india_guwahati.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_guwahati.md
+++ b/content/project/case-studies/india_guwahati.md
@@ -7,6 +7,7 @@ thumbnail: "images/india_guwahati1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_guwahati.md
+++ b/content/project/case-studies/india_guwahati.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/india_guwahati1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_hyderabad.md
+++ b/content/project/case-studies/india_hyderabad.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_hyderabad.md
+++ b/content/project/case-studies/india_hyderabad.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/india_hyderabad1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_hyderabad.md
+++ b/content/project/case-studies/india_hyderabad.md
@@ -7,6 +7,7 @@ thumbnail: "images/india_hyderabad1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_pune.md
+++ b/content/project/case-studies/india_pune.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_pune.md
+++ b/content/project/case-studies/india_pune.md
@@ -7,6 +7,7 @@ thumbnail: "images/india_pune1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/india_pune.md
+++ b/content/project/case-studies/india_pune.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/india_pune1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_cesena.md
+++ b/content/project/case-studies/italy_cesena.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_cesena.md
+++ b/content/project/case-studies/italy_cesena.md
@@ -7,6 +7,7 @@ thumbnail: "images/italy_cesena1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_cesena.md
+++ b/content/project/case-studies/italy_cesena.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/italy_cesena1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_rome.md
+++ b/content/project/case-studies/italy_rome.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_rome.md
+++ b/content/project/case-studies/italy_rome.md
@@ -7,6 +7,7 @@ thumbnail: "images/italy_igag1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_rome.md
+++ b/content/project/case-studies/italy_rome.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/italy_igag1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_turin.md
+++ b/content/project/case-studies/italy_turin.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/italy_turin1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_turin.md
+++ b/content/project/case-studies/italy_turin.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_turin.md
+++ b/content/project/case-studies/italy_turin.md
@@ -7,6 +7,7 @@ thumbnail: "images/italy_turin1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_vicenza.md
+++ b/content/project/case-studies/italy_vicenza.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/italy_vicenza1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_vicenza.md
+++ b/content/project/case-studies/italy_vicenza.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/italy_vicenza.md
+++ b/content/project/case-studies/italy_vicenza.md
@@ -7,6 +7,7 @@ thumbnail: "images/italy_vicenza1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/malaysia_kuala.md
+++ b/content/project/case-studies/malaysia_kuala.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/malaysia_kuala.md
+++ b/content/project/case-studies/malaysia_kuala.md
@@ -7,6 +7,7 @@ thumbnail: "images/malaysia_kuala1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/malaysia_kuala.md
+++ b/content/project/case-studies/malaysia_kuala.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/malaysia_kuala1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/mexico_jalisco.md
+++ b/content/project/case-studies/mexico_jalisco.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/mexico_jalisco1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/mexico_jalisco.md
+++ b/content/project/case-studies/mexico_jalisco.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/mexico_jalisco.md
+++ b/content/project/case-studies/mexico_jalisco.md
@@ -7,6 +7,7 @@ thumbnail: "images/mexico_jalisco1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/nigeria_jos.md
+++ b/content/project/case-studies/nigeria_jos.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/nigeria_jos.md
+++ b/content/project/case-studies/nigeria_jos.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/nigeria_jos1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/nigeria_jos.md
+++ b/content/project/case-studies/nigeria_jos.md
@@ -7,6 +7,7 @@ thumbnail: "images/nigeria_jos1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/poland_ffth.md
+++ b/content/project/case-studies/poland_ffth.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/poland_ffth/toolbox.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/poland_ffth.md
+++ b/content/project/case-studies/poland_ffth.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/poland_ffth.md
+++ b/content/project/case-studies/poland_ffth.md
@@ -7,6 +7,7 @@ thumbnail: "images/poland_ffth/toolbox.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_coimbra.md
+++ b/content/project/case-studies/portugal_coimbra.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_coimbra.md
+++ b/content/project/case-studies/portugal_coimbra.md
@@ -7,6 +7,7 @@ thumbnail: "images/portugal_coimbra1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_coimbra.md
+++ b/content/project/case-studies/portugal_coimbra.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/portugal_coimbra1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_evora.md
+++ b/content/project/case-studies/portugal_evora.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_evora.md
+++ b/content/project/case-studies/portugal_evora.md
@@ -7,6 +7,7 @@ thumbnail: "images/portugal_evora1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_evora.md
+++ b/content/project/case-studies/portugal_evora.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/portugal_evora1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_funchal.md
+++ b/content/project/case-studies/portugal_funchal.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_funchal.md
+++ b/content/project/case-studies/portugal_funchal.md
@@ -7,6 +7,7 @@ thumbnail: "images/portugal_funchal1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_funchal.md
+++ b/content/project/case-studies/portugal_funchal.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/portugal_funchal1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_lisbon.md
+++ b/content/project/case-studies/portugal_lisbon.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_lisbon.md
+++ b/content/project/case-studies/portugal_lisbon.md
@@ -7,6 +7,7 @@ thumbnail: "images/portugal_lisbon1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_lisbon.md
+++ b/content/project/case-studies/portugal_lisbon.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/portugal_lisbon1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_pinhel.md
+++ b/content/project/case-studies/portugal_pinhel.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_pinhel.md
+++ b/content/project/case-studies/portugal_pinhel.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/portugal_pinhel1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_pinhel.md
+++ b/content/project/case-studies/portugal_pinhel.md
@@ -7,6 +7,7 @@ thumbnail: "images/portugal_pinhel1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_ribeira.md
+++ b/content/project/case-studies/portugal_ribeira.md
@@ -7,6 +7,7 @@ thumbnail: "images/portugal_ribeira1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_ribeira.md
+++ b/content/project/case-studies/portugal_ribeira.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/portugal_ribeira1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_ribeira.md
+++ b/content/project/case-studies/portugal_ribeira.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_torres.md
+++ b/content/project/case-studies/portugal_torres.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_torres.md
+++ b/content/project/case-studies/portugal_torres.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/portugal_torres1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_torres.md
+++ b/content/project/case-studies/portugal_torres.md
@@ -7,6 +7,7 @@ thumbnail: "images/portugal_torres1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/portugal_trees_inventory.md
+++ b/content/project/case-studies/portugal_trees_inventory.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: "2025-06-08"
 featured: false
+archived: false
 ---
 
 {{< content-start >}}

--- a/content/project/case-studies/portugal_trees_inventory.md
+++ b/content/project/case-studies/portugal_trees_inventory.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/portugal_trees_inventory3.webp"
 section: "project"
 type: "case-study"
+date: "2025-06-08"
 ---
 
 {{< content-start >}}

--- a/content/project/case-studies/portugal_trees_inventory.md
+++ b/content/project/case-studies/portugal_trees_inventory.md
@@ -7,6 +7,7 @@ thumbnail: "images/portugal_trees_inventory3.webp"
 section: "project"
 type: "case-study"
 date: "2025-06-08"
+featured: false
 ---
 
 {{< content-start >}}

--- a/content/project/case-studies/qgis_at_financial_times.md
+++ b/content/project/case-studies/qgis_at_financial_times.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/qgis_at_financial_times.md
+++ b/content/project/case-studies/qgis_at_financial_times.md
@@ -7,6 +7,7 @@ thumbnail: "images/ft_europe_migration_balkan-route.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/qgis_at_financial_times.md
+++ b/content/project/case-studies/qgis_at_financial_times.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/ft_europe_migration_balkan-route.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/suisse_basel.md
+++ b/content/project/case-studies/suisse_basel.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/suisse_basel.md
+++ b/content/project/case-studies/suisse_basel.md
@@ -7,6 +7,7 @@ thumbnail: "images/suisse_basel1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/suisse_basel.md
+++ b/content/project/case-studies/suisse_basel.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/suisse_basel1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/suisse_solothurn.md
+++ b/content/project/case-studies/suisse_solothurn.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/suisse_solothurn.md
+++ b/content/project/case-studies/suisse_solothurn.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/suisse_solothurn1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/suisse_solothurn.md
+++ b/content/project/case-studies/suisse_solothurn.md
@@ -7,6 +7,7 @@ thumbnail: "images/suisse_solothurn1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/suisse_uster.md
+++ b/content/project/case-studies/suisse_uster.md
@@ -7,6 +7,7 @@ thumbnail: "images/suisse_uster1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/suisse_uster.md
+++ b/content/project/case-studies/suisse_uster.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/suisse_uster1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/suisse_uster.md
+++ b/content/project/case-studies/suisse_uster.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/tanzania_udzungwa.md
+++ b/content/project/case-studies/tanzania_udzungwa.md
@@ -7,6 +7,7 @@ thumbnail: "images/tanzania_udzungwa1.jpg"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/tanzania_udzungwa.md
+++ b/content/project/case-studies/tanzania_udzungwa.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/tanzania_udzungwa.md
+++ b/content/project/case-studies/tanzania_udzungwa.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/tanzania_udzungwa1.jpg"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/ukrainian_spt.md
+++ b/content/project/case-studies/ukrainian_spt.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/ukrainian_spt.md
+++ b/content/project/case-studies/ukrainian_spt.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/ukraine_spt1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/ukrainian_spt.md
+++ b/content/project/case-studies/ukrainian_spt.md
@@ -7,6 +7,7 @@ thumbnail: "images/ukraine_spt1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/uruguay_mides.md
+++ b/content/project/case-studies/uruguay_mides.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/uruguay_mides.md
+++ b/content/project/case-studies/uruguay_mides.md
@@ -7,6 +7,7 @@ thumbnail: "images/uruguay_mides1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/uruguay_mides.md
+++ b/content/project/case-studies/uruguay_mides.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/uruguay_mides1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/usa_missouri.md
+++ b/content/project/case-studies/usa_missouri.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/usa_missouri.md
+++ b/content/project/case-studies/usa_missouri.md
@@ -7,6 +7,7 @@ thumbnail: "images/usa_missouri1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/usa_missouri.md
+++ b/content/project/case-studies/usa_missouri.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/usa_missouri1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/usa_polczynski.md
+++ b/content/project/case-studies/usa_polczynski.md
@@ -8,6 +8,7 @@ section: "project"
 type: "case-study"
 date: 2024-02-16
 featured: false
+archived: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/usa_polczynski.md
+++ b/content/project/case-studies/usa_polczynski.md
@@ -7,6 +7,7 @@ thumbnail: "images/usa_polczynski_table1.png"
 section: "project"
 type: "case-study"
 date: 2024-02-16
+featured: false
 ---
 {{< content-start >}}
 

--- a/content/project/case-studies/usa_polczynski.md
+++ b/content/project/case-studies/usa_polczynski.md
@@ -6,6 +6,7 @@ sidebar: true
 thumbnail: "images/usa_polczynski_table1.png"
 section: "project"
 type: "case-study"
+date: 2024-02-16
 ---
 {{< content-start >}}
 

--- a/playwright/ci-test/tests/03-project-page.spec.ts
+++ b/playwright/ci-test/tests/03-project-page.spec.ts
@@ -39,7 +39,6 @@ test("Project page", async ({ homePage, sidebar, projectPage }) => {
     await expect(projectPage.localUserGroupsHeading).toBeVisible();
     await expect(projectPage.localGroupsListLink).toBeVisible();
     await expect(projectPage.joinTheCommunityLink).toBeVisible();
-    await expect(projectPage.amurumForestLink).toBeVisible();
 
     for (const text of projectPage.projectTextList) {
         await expect(projectPage.pageBody).toContainText(text);
@@ -62,7 +61,6 @@ test("Project page", async ({ homePage, sidebar, projectPage }) => {
         await expect(projectPage.pageBody).toContainText(text);
     }
 
-    await expect(projectPage.amurumForestLink).toBeVisible();
     await expect(sidebar.pluginsLink).toBeVisible();
     await sidebar.visualChangelogsLink.click();
 

--- a/playwright/ci-test/tests/fixtures/project-page.ts
+++ b/playwright/ci-test/tests/fixtures/project-page.ts
@@ -13,10 +13,8 @@ export class ProjectPage {
     public readonly localUserGroupsHeading: Locator;
     public readonly localGroupsListLink: Locator;
     public readonly joinTheCommunityLink: Locator;
-    public readonly amurumForestLink: Locator;
     public readonly mapsLink: Locator;
     public readonly screenshotsLink: Locator;
-    public readonly caseStudiesAmurumLink: Locator;
     public readonly projectTextList: string[] = [
         "Free and open source",
         "QGIS overview",
@@ -96,9 +94,6 @@ export class ProjectPage {
         this.joinTheCommunityLink = this.page.getByRole("link", {
             name: "Join the community",
         });
-        this.amurumForestLink = this.page.getByRole("link", {
-            name: "Amurum forest reserve habitat",
-        });
         this.mapsLink = this.page.getByRole("link", {
             name: "Maps",
             exact: true,
@@ -106,8 +101,5 @@ export class ProjectPage {
         this.screenshotsLink = this.page.getByRole("link", {
             name: "Screenshots",
         }).first();
-        this.caseStudiesAmurumLink = this.page.getByRole("link", {
-            name: "Amurum forest reserve habitat",
-        });
     }
 }

--- a/themes/hugo-bulma-blocks-theme/assets/js/carousel.js
+++ b/themes/hugo-bulma-blocks-theme/assets/js/carousel.js
@@ -1,0 +1,78 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const carousel = document.querySelector('.carousel');
+    const items = document.querySelectorAll('.carousel-item');
+    const prevBtn = document.querySelector('.carousel-nav-prev');
+    const nextBtn = document.querySelector('.carousel-nav-next');
+    const indicators = document.querySelectorAll('.carousel-indicator');
+    
+    let currentIndex = 0;
+    let intervalId = null;
+    const intervalDuration = 5000; // 5 seconds
+    
+    // Initialize carousel
+    function initCarousel() {
+        updateCarousel();
+        startAutoSlide();
+        
+        // Event listeners
+        prevBtn.addEventListener('click', () => {
+            navigate(-1);
+            resetAutoSlide();
+        });
+        
+        nextBtn.addEventListener('click', () => {
+            navigate(1);
+            resetAutoSlide();
+        });
+        
+        // Indicator clicks
+        indicators.forEach((indicator, index) => {
+            indicator.addEventListener('click', () => {
+                if (index !== currentIndex) {
+                    currentIndex = index;
+                    updateCarousel();
+                    resetAutoSlide();
+                }
+            });
+        });
+    }
+    
+    // Navigate through items
+    function navigate(direction) {
+        currentIndex = (currentIndex + direction + items.length) % items.length;
+        updateCarousel();
+    }
+    
+    // Update carousel display
+    function updateCarousel() {
+        // Hide all items
+        items.forEach(item => item.classList.remove('is-active'));
+        
+        // Show current item
+        items[currentIndex].classList.add('is-active');
+        
+        // Update indicators
+        indicators.forEach((indicator, index) => {
+            if (index === currentIndex) {
+                indicator.classList.add('is-active');
+            } else {
+                indicator.classList.remove('is-active');
+            }
+        });
+    }
+    
+    // Auto slide functionality
+    function startAutoSlide() {
+        intervalId = setInterval(() => {
+            navigate(1);
+        }, intervalDuration);
+    }
+    
+    function resetAutoSlide() {
+        clearInterval(intervalId);
+        startAutoSlide();
+    }
+    
+    // Initialize
+    initCarousel();
+});

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/_all.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/_all.sass
@@ -23,3 +23,4 @@
 @import "payrexx"
 @import "feed"
 @import "context-menu"
+@import "carousel"

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/carousel.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/carousel.sass
@@ -98,6 +98,14 @@
 // Mobile adjustments
 @include mobile
   .carousel-container
+    .carousel
+      min-height: 400px !important
+      .carousel-item
+        .card
+          .card-image
+            img
+              height: 250px !important
+              object-fit: contain !important
     .carousel-nav
       width: 40px
       height: 40px

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/carousel.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/carousel.sass
@@ -46,7 +46,7 @@
 
   .carousel-nav
     position: absolute
-    top: 35%
+    top: 50%
     transform: translateY(-50%)
     background: $primary1
     border: none

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/carousel.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/carousel.sass
@@ -20,9 +20,15 @@
       box-sizing: border-box
       opacity: 0
       transition: opacity 0.5s ease-in-out
+      a
+        display: none
+        z-index: -1
 
       &.is-active
         opacity: 1
+        a
+          display: inline-flex
+          z-index: 1
 
       .card
         height: 98%

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/carousel.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/carousel.sass
@@ -104,7 +104,7 @@
         .card
           .card-image
             img
-              height: 250px !important
+              height: 220px !important
               object-fit: contain !important
     .carousel-nav
       width: 40px

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/carousel.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/carousel.sass
@@ -1,0 +1,108 @@
+// Carousel container
+.carousel-container
+  position: relative
+  margin: 0 auto
+  overflow: hidden
+
+  // Carousel main element
+  .carousel
+    position: relative
+    min-height: 520px
+
+    // Carousel items
+    .carousel-item
+      position: absolute
+      top: 0
+      left: 0
+      width: 100%
+      height: 98%
+      padding: 0 10px
+      box-sizing: border-box
+      opacity: 0
+      transition: opacity 0.5s ease-in-out
+
+      &.is-active
+        opacity: 1
+
+      .card
+        height: 98%
+        border: 1px solid #ccd2d6
+        max-width: fit-content
+        margin: 0 auto
+
+        .card-image
+          .image
+            margin: 0
+
+            img
+              height: 360px
+              object-fit: cover
+
+  .carousel-nav
+    position: absolute
+    top: 35%
+    transform: translateY(-50%)
+    background: $primary1
+    border: none
+    border-radius: 50%
+    width: 50px
+    height: 50px
+    display: flex
+    align-items: center
+    justify-content: center
+    cursor: pointer
+    z-index: 10
+    transition: all 0.3s ease
+
+    .icon
+      color: white
+
+    &.carousel-nav-prev
+      left: 20px
+
+    &.carousel-nav-next
+      right: 20px
+
+  // Indicators
+  .carousel-indicators
+    position: absolute
+    bottom: 30px
+    left: 50%
+    transform: translateX(-50%)
+    display: flex
+    gap: 10px
+    z-index: 10
+
+    .carousel-indicator
+      width: 12px
+      height: 12px
+      border-radius: 50%
+      background: rgba(188, 188, 188, 0.5)
+      border: none
+      cursor: pointer
+      transition: all 0.3s ease
+
+      &.is-active
+        background: $primary1
+        transform: scale(1.2)
+
+      &:hover:not(.is-active)
+        background: $primary4
+
+// Mobile adjustments
+@include mobile
+  .carousel-container
+    .carousel-nav
+      width: 40px
+      height: 40px
+
+    .carousel-indicators
+      .carousel-indicator
+        width: 10px
+        height: 10px
+
+// Utility classes
+.truncate-one-line
+  overflow: hidden
+  text-overflow: ellipsis
+  white-space: nowrap

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/usecases-archive.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/usecases-archive.html
@@ -1,0 +1,13 @@
+{{ $archived := where (where (where .Site.Pages "Section" "project") ".Params.type" "case-study") ".Params.archived" true }}
+
+<h2>Archived Case Studies</h2>
+{{ if gt (len $archived) 0 }}
+<div class="grid">
+  {{ range sort $archived "Date" "desc" }}
+    {{ partial "usecase.html" . }}
+  {{ end }}
+</div>
+{{ else }}
+
+<p>No archived case studies available at the moment. Check back soon for more stories!</p>
+{{ end }}

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/usecases-archive.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/usecases-archive.html
@@ -1,6 +1,5 @@
 {{ $archived := where (where (where .Site.Pages "Section" "project") ".Params.type" "case-study") ".Params.archived" true }}
 
-<h2>Archived Case Studies</h2>
 {{ if gt (len $archived) 0 }}
 <div class="grid">
   {{ range sort $archived "Date" "desc" }}

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/usecases.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/usecases.html
@@ -1,5 +1,5 @@
 <div class="grid">
-  {{ range where .Site.Pages "Section" "project" }}
+  {{ range sort (where .Site.Pages "Section" "project") "Date" "desc" }}
     {{ if eq (index .Params "type") "case-study" }}
       {{ partial "usecase.html" . }}
     {{ end }}

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/usecases.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/usecases.html
@@ -1,26 +1,24 @@
-{{ $featured := where (where (where .Site.Pages "Section" "project") ".Params.type" "case-study") ".Params.featured" true }}
+{{ $featured := where (where (where (where .Site.Pages "Section" "project") ".Params.type" "case-study") ".Params.featured" true) ".Params.archived" false }}
 
 <h2>🌟 Featured Case Studies</h2>
 {{ if gt (len $featured) 0 }}
 <div class="carousel-container mb-5">
     <div class="carousel">
         <!-- Carousel Items -->
-        {{ range sort (where .Site.Pages "Section" "project") "Date" "desc" }}
-            {{ if and (eq (index .Params "type") "case-study") (index .Params "featured") }}
-              <div class="carousel-item is-active">
-                  <div class="card">
-                      <div class="card-image">
-                          <figure class="image">
-                              <img src="{{ absURL "project/case-studies/" }}{{ .Params.thumbnail }}" alt="Product 1">
-                          </figure>
-                      </div>
-                      <div class="card-content has-text-centered">
-                          <p class="title is-6 truncate-one-line">{{.Title}}</p>
-                          <a class="button is-success is-rounded" href="{{ .RelPermalink }}">More details</a>
-                      </div>
-                  </div>
-              </div>
-            {{ end }}
+        {{ range $i, $item := sort $featured "Date" "desc" }}
+        <div class="carousel-item{{ if eq $i 0 }} is-active{{ end }}">
+          <div class="card">
+            <div class="card-image">
+              <figure class="image">
+                <img src="{{ absURL "project/case-studies/" }}{{ $item.Params.thumbnail }}" alt="{{ $item.Title }}">
+              </figure>
+            </div>
+            <div class="card-content has-text-centered">
+              <p class="title is-6 truncate-one-line">{{ $item.Title }}</p>
+              <a class="button is-success is-rounded" href="{{ $item.RelPermalink }}">More details</a>
+            </div>
+          </div>
+        </div>
         {{ end }}
     </div>
     
@@ -50,13 +48,24 @@
 <p>No featured case studies available at the moment. Check back soon for highlighted success stories!</p>
 {{ end }}
 
+{{ $active := where (where (where .Site.Pages "Section" "project") ".Params.type" "case-study") ".Params.archived" false }}
+
 <h2>Active Case Studies</h2>
 
+{{ if gt (len $active) 0 }}
 <div class="grid">
-  {{ range sort (where .Site.Pages "Section" "project") "Date" "desc" }}
+  {{ range sort $active "Date" "desc" }}
     {{ if eq (index .Params "type") "case-study" }}
       {{ partial "usecase.html" . }}
     {{ end }}
   {{ end }}
 </div>
-  
+{{ else }}
+<p>No active case studies available at the moment. Check back soon for updates!</p>
+{{ end }}
+
+<h2>Archived Case Studies</h2>
+<p>
+  More case studies are available in our <a href="{{ absURL "project/case-studies-archive" }}">archive</a>. You can explore past projects and their outcomes to see how our solutions have evolved over time.
+</p>
+<a href="{{ absURL "project/case-studies-archive" }}" class="button is-primary3 is-rounded ml-2">View Archive</a>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/usecases.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/usecases.html
@@ -1,3 +1,57 @@
+{{ $featured := where (where (where .Site.Pages "Section" "project") ".Params.type" "case-study") ".Params.featured" true }}
+
+<h2>🌟 Featured Case Studies</h2>
+{{ if gt (len $featured) 0 }}
+<div class="carousel-container mb-5">
+    <div class="carousel">
+        <!-- Carousel Items -->
+        {{ range sort (where .Site.Pages "Section" "project") "Date" "desc" }}
+            {{ if and (eq (index .Params "type") "case-study") (index .Params "featured") }}
+              <div class="carousel-item is-active">
+                  <div class="card">
+                      <div class="card-image">
+                          <figure class="image">
+                              <img src="{{ absURL "project/case-studies/" }}{{ .Params.thumbnail }}" alt="Product 1">
+                          </figure>
+                      </div>
+                      <div class="card-content has-text-centered">
+                          <p class="title is-6 truncate-one-line">{{.Title}}</p>
+                          <a class="button is-success is-rounded" href="{{ .RelPermalink }}">More details</a>
+                      </div>
+                  </div>
+              </div>
+            {{ end }}
+        {{ end }}
+    </div>
+    
+    <!-- Navigation Arrows -->
+    <button class="carousel-nav carousel-nav-prev">
+        <span class="icon is-large">
+            <i class="fas fa-chevron-left fa-2x"></i>
+        </span>
+    </button>
+    <button class="carousel-nav carousel-nav-next">
+        <span class="icon is-large">
+            <i class="fas fa-chevron-right fa-2x"></i>
+        </span>
+    </button>
+    
+    <!-- Indicators -->
+    <div class="carousel-indicators">
+      {{ range $i, $item := $featured }}
+        <button class="carousel-indicator{{ if eq $i 0 }} is-active{{ end }}"></button>
+      {{ end }}
+    </div>
+</div>
+{{ $carouseljs := resources.Get "js/carousel.js" | resources.Minify }}
+<script src="{{ $carouseljs.RelPermalink }}"></script>
+{{ else }}
+
+<p>No featured case studies available at the moment. Check back soon for highlighted success stories!</p>
+{{ end }}
+
+<h2>Active Case Studies</h2>
+
 <div class="grid">
   {{ range sort (where .Site.Pages "Section" "project") "Date" "desc" }}
     {{ if eq (index .Params "type") "case-study" }}


### PR DESCRIPTION
Closes #684 

Hi @timlinux, is there a way to know the real date for each case study? For the latest one, I just added it based on the date of the PR, but for the other ones, their date of modification is not real, just related to the migration to the new website.

Closes #685 

- [x] Added two fields to the front matter of each case study: `featured` and `archived`. Default values for both fields are set to `false`
- [x] Featured case studies carousel on the main page. This will only show case studies with `featured: true` and `archived: false` set. It will switch automatically to the next one every 5 seconds.
- [x] Archived case studies page. This will only show case studies with `archived: true` set
- [x] Active case studies list has been filtered to include only case studies with `archived: false`

<img width="1481" height="1158" alt="image" src="https://github.com/user-attachments/assets/b5a4a413-f870-4f9e-b338-fc2e185262fb" />

<img width="1532" height="802" alt="image" src="https://github.com/user-attachments/assets/d5047c1c-5544-4748-987b-f0505b71570e" />

<img width="1382" height="707" alt="image" src="https://github.com/user-attachments/assets/cce810ca-024d-43f4-ae75-33118a7aec97" />

<img width="370" height="668" alt="image" src="https://github.com/user-attachments/assets/bf990444-38bd-4a5f-b7eb-4884c6884a7c" />
