### PR TITLE
Fix the Supported distribution versions table formatting

### DIFF
--- a/content/resources/installation-guide/index.md
+++ b/content/resources/installation-guide/index.md
@@ -205,7 +205,7 @@ Next release: {{< param "nextreleasedate" >}}
 #### Supported distribution versions: {#available-codenames}
 
 |Distribution|Version         |Codename             |Also available based on ubuntugis-unstable dependencies?|
-|------------+----------------+---------------------+--------------------------------------------------------|
+|------------|----------------|-------------------|--------------------------------------------------------|
 |Debian      |12.x (stable)   |bookworm             |                                                        |
 |            |13.x (testing)  |trixie [[3]](#id3)   |                                                        |
 |            |unstable        |sid                  |                                                        |


### PR DESCRIPTION
This should fix the format of the table at https://qgis.org/resources/installation-guide/#available-codenames

<img width="1015" height="425" alt="image" src="https://github.com/user-attachments/assets/60d4274a-0c37-40e0-9b27-57ebee206b03" />
