### PR TITLE
Separate contributors tabs to different pages and add permalinks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -310,25 +310,40 @@ sectionPagesMenu = 'main'
   name = "Mailing Lists"
   url = "/community/organisation/mailinglists"
   weight = 220
-  
-[[menu.main]]
-  parent = "Community"
-  name = "Members Blogs"
-  url = "https://planet.qgis.org"
-  weight = 280
 
 
 [[menu.main]]
   parent = "Community"
   name = "Contributors"
   url = "/community/contributors"
-  weight = 280
+  weight = 240
 
 [[menu.main]]
   parent = "Contributors"
-  name = "Add your Organisation"
-  url = "/community/contributors/add-organisation"
+  name = "Organizations"
+  url = "/community/contributors/organisations"
+  weight = 241
+
+
+[[menu.main]]
+  parent = "Contributors"
+  name = "Individuals"
+  url = "/community/contributors/individuals"
+  weight = 242
+
+
+[[menu.main]]
+  parent = "Contributors"
+  name = "Supporting"
+  url = "/community/contributors/supporting"
+  weight = 243
+
+[[menu.main]]
+  parent = "Community"
+  name = "Members Blogs"
+  url = "https://planet.qgis.org"
   weight = 280
+
 
 [[menu.main]]
   name = "Resources"

--- a/content/community/contributors.md
+++ b/content/community/contributors.md
@@ -11,18 +11,16 @@ sidebar: true
 {{< content-start >}}
 
 {{< contribution-stats >}}
-{{< tabs tab1="🏢 Organizations" tab2="🧑‍💻 Individuals" tab3="🙋 Supporting" >}}
-{{< tab-content-start tab="1" >}}
 
 {{< rich-box-start icon="🏢" layoutClass="tips">}}
 {{< rich-content-start themeClass="coloring-1" >}}
 
 ## Contributing Organizations
-These organizations actively contribute to QGIS, as reflected by their GitHub commit activity.
+Organizations making meaningful contributions to the QGIS project through development and collaboration
 
 <div style="text-align:center;">
-	<a href="/community/contributors/add-organisation/" class="button is-success">
-		🚀 Add your Organisation!
+	<a href="/community/contributors/organisations/" class="button is-success">
+		View list
 	</a>
 </div>
 
@@ -30,40 +28,38 @@ These organizations actively contribute to QGIS, as reflected by their GitHub co
 {{< rich-content-end >}}
 {{< rich-box-end >}}
 
-{{< contributing-orgs >}}
-{{< tab-content-end >}}
 
-{{< tab-content-start tab="2" >}}
 
 {{< rich-box-start icon="🧑‍💻" layoutClass="tips">}}
 {{< rich-content-start themeClass="coloring-1" >}}
 ## Individual Contributors
-This list features individuals who contribute to QGIS, based on their activity (commits) on GitHub.
+Celebrating the developers and contributors who help build QGIS through their code contributions and collaborative efforts.
 
-{{< rich-content-end >}}
-{{< rich-box-end >}}
-
-{{< individual-contributors >}}
-{{< tab-content-end >}}
-
-{{< tab-content-start tab="3" >}}
-
-{{< rich-box-start icon="🙋" layoutClass="tips">}}
-{{< rich-content-start themeClass="coloring-1" >}}
-## Supporting Contributors
-This list highlights individuals and organizations whose valuable contributions to QGIS may not be reflected in commit histories—such as community support, outreach, or other behind-the-scenes efforts. If you believe your work should be recognized here, please fill out the [QGIS Supporting Contributors Application form](https://forms.gle/wZr4EfCjqPWGaoq37). The QGIS Project Steering Committee (PSC) reviews submissions on a monthly basis.
 
 <div style="text-align:center;">
-  <a href="https://forms.gle/wZr4EfCjqPWGaoq37" class="button is-success">
-    🚀 Submit Your Contribution
-  </a>
+	<a href="/community/contributors/individuals/" class="button is-success">
+		View list
+	</a>
 </div>
 
 {{< rich-content-end >}}
 {{< rich-box-end >}}
 
 
-{{< supporting-contributors >}}
 
-{{< tab-content-end >}}
+{{< rich-box-start icon="🙋" layoutClass="tips">}}
+{{< rich-content-start themeClass="coloring-1" >}}
+## Supporting Contributors
+Recognizing valuable contributions beyond code commits—community support, outreach, and behind-the-scenes efforts.
+
+
+<div style="text-align:center;">
+	<a href="/community/contributors/supporting/" class="button is-success">
+		View list
+	</a>
+</div>
+
+{{< rich-content-end >}}
+{{< rich-box-end >}}
+
 {{< content-end >}}

--- a/content/community/contributors/individuals.md
+++ b/content/community/contributors/individuals.md
@@ -1,0 +1,23 @@
+---
+type: "page"
+title: "Individual Contributors"
+subtitle: "Celebrating the developers and contributors who help build QGIS through their code contributions and collaborative efforts."
+draft: false
+HasBanner: true
+heroImage: "img/involve.jpg"
+sidebar: true
+---
+
+{{< content-start >}}
+
+{{< rich-box-start icon="🧑‍💻" layoutClass="tips">}}
+{{< rich-content-start themeClass="coloring-1" >}}
+## Individual Contributors
+This list features individuals who contribute to QGIS, based on their activity (commits) on GitHub.
+
+{{< rich-content-end >}}
+{{< rich-box-end >}}
+
+{{< individual-contributors >}}
+
+{{< content-end >}}

--- a/content/community/contributors/organisations.md
+++ b/content/community/contributors/organisations.md
@@ -1,0 +1,31 @@
+---
+type: "page"
+title: "Contributing Organizations"
+subtitle: "Organizations making meaningful contributions to the QGIS project through development and collaboration"
+draft: false
+HasBanner: true
+heroImage: "img/involve.jpg"
+sidebar: true
+---
+
+{{< content-start >}}
+
+{{< rich-box-start icon="🏢" layoutClass="tips">}}
+{{< rich-content-start themeClass="coloring-1" >}}
+
+## Contributing Organizations
+These organizations actively contribute to QGIS, as reflected by their GitHub commit activity.
+
+<div style="text-align:center;">
+	<a href="/community/contributors/add-organisation/" class="button is-success">
+		🚀 Add your Organisation!
+	</a>
+</div>
+
+
+{{< rich-content-end >}}
+{{< rich-box-end >}}
+
+{{< contributing-orgs >}}
+
+{{< content-end >}}

--- a/content/community/contributors/supporting.md
+++ b/content/community/contributors/supporting.md
@@ -1,0 +1,31 @@
+---
+type: "page"
+title: "Supporting Contributors"
+subtitle: "Recognizing valuable contributions beyond code commits—community support, outreach, and behind-the-scenes efforts."
+draft: false
+HasBanner: true
+heroImage: "img/involve.jpg"
+sidebar: true
+---
+
+{{< content-start >}}
+
+
+{{< rich-box-start icon="🙋" layoutClass="tips">}}
+{{< rich-content-start themeClass="coloring-1" >}}
+## Supporting Contributors
+This list highlights individuals and organizations whose valuable contributions to QGIS may not be reflected in commit histories—such as community support, outreach, or other behind-the-scenes efforts. If you believe your work should be recognized here, please fill out the [QGIS Supporting Contributors Application form](https://forms.gle/wZr4EfCjqPWGaoq37). The QGIS Project Steering Committee (PSC) reviews submissions on a monthly basis.
+
+<div style="text-align:center;">
+  <a href="https://forms.gle/wZr4EfCjqPWGaoq37" class="button is-success">
+    🚀 Submit Your Contribution
+  </a>
+</div>
+
+{{< rich-content-end >}}
+{{< rich-box-end >}}
+
+
+{{< supporting-contributors >}}
+
+{{< content-end >}}

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/contributing-orgs.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/contributing-orgs.html
@@ -21,8 +21,11 @@
                 </div>
                 <div class="column is-two-third">
                     <div class="org-info">
-                        <h3 class="title is-3">
+                        <h3 class="title is-3" id="{{ $org.name | urlize }}">
                             <a href="{{ $org.url }}" class= "external-link" target="_blank" rel="noopener">{{ $org.name }}</a>
+                            <a class="heading-anchor" href="#{{ $org.name | urlize }}">
+                                ¶
+                            </a>
                         </h3>
                         <p class="subtitle is-5">{{ $org.subtitle }}</p>
                         <div class="content">

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/individual-contributors.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/individual-contributors.html
@@ -2,13 +2,16 @@
 <div class="columns is-multiline">
     {{ range $idx, $contributor := $contributors }}
     <div class="column is-one-third">
-        <div class="card contributor-card individual">
+        <div class="card contributor-card individual" id="{{ .login | urlize }}">
             <div class="card-content has-text-centered">
                 <div class="avatar-container">
                     <img src="{{ $contributor.avatar_url }}" alt="{{ $contributor.login }}" class="avatar" loading="lazy">
                     <span class="level-indicator level-5 p-1"># {{ add $idx 1 }}</span>
                 </div>
                 <h3 class="title is-4">
+                    <a class="heading-anchor" href="#{{ .login | urlize }}" style="margin-left: -22.3px;">
+                        ¶
+                    </a>
                     <a href="https://github.com/{{ .login }}" class="external-link" target="_blank" rel="noopener">
                         {{ .login }}
                     </a>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/supporting-contributors.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/supporting-contributors.html
@@ -2,12 +2,15 @@
 <div class="columns is-multiline">
     {{ range $idx, $contributor := $contributors }}
     <div class="column is-one-third">
-        <div class="card contributor-card individual">
+        <div class="card contributor-card individual" id="{{ .name | urlize}}">
             <div class="card-content has-text-centered">
                 <div class="avatar-container">
                     <img src="{{ $contributor.avatar_img }}" alt="{{ $contributor.name }}" class="avatar" loading="lazy">
                 </div>
                 <h3 class="title is-4">
+                    <a class="heading-anchor" href="#{{ .name | urlize }}" style="margin-left: -22.3px;">
+                        ¶
+                    </a>
                     {{ if .link }}
                         <a href="{{ .link }}" class="external-link" target="_blank" rel="noopener">
                             {{ .name }}


### PR DESCRIPTION
Closes #764 

## Changes summary

- Refactor the https://qgis.org/community/contributors/ page to only list contributor categories and add a link to each list
- Add permalink to each organisation, individual and supporting contributors item so we could have something like: https://qgis.org/community/contributors/organisations/#kartoza-pty-ltd. and https://qgis.org/community/contributors/individuals/#xpirix

<img width="1381" height="852" alt="image" src="https://github.com/user-attachments/assets/9a3d6081-439a-4ccf-9804-c9ef0ab21a7b" />

<img width="1393" height="923" alt="image" src="https://github.com/user-attachments/assets/70d89035-95a3-4533-8ffc-5af808466801" />

<img width="1390" height="573" alt="image" src="https://github.com/user-attachments/assets/6e20271a-ee80-4350-9cfc-7b8eb697711c" />
