### PR TITLE
Improve user groups page

### DIFF
--- a/content/community/groups.md
+++ b/content/community/groups.md
@@ -135,7 +135,7 @@ Reviewer: Tim Sutton
     
 *   Initialization/coordination of application modules, e.g. surveying, urban planning, server/web client, etc.
     
-*   Electing a representative to act as a [QGIS Country Voting Member]({{< ref "/community/organisation#voting-members" >}})
+*   Electing a representative to act as a [QGIS Voting Member]({{< ref "/community/organisation#voting-members" >}})
     
 
 ## General assumptions/recommendations

--- a/content/community/groups.md
+++ b/content/community/groups.md
@@ -182,9 +182,17 @@ Your local user group website should be used to publish any material in relation
 Good luck with organizing your local user group! Please inform the international QGIS team by registering at the QGIS community list and reporting about your progress. Please do not hesitate to ask questions regarding the establishment and maintenance of your local user group.
 
 
-## Website template
+## Starter pack
+### QGIS.org subdomain hosting
 
+If you prefer to use the official QGIS.org branding and host your user group website on a QGIS.org subdomain (e.g., `sweden.qgis.org`), you can utilize the provided template repository at [https://github.com/qgis/QGIS-User-Group-Website](https://github.com/qgis/QGIS-User-Group-Website). This option ensures consistency with the main QGIS website design. Please carefully read and follow the setup instructions provided in the repository.
 
-If you do not wish to host and design your website from scratch, you can use the template provided at [https://github.com/qgis/qgis-template.github.io](https://github.com/qgis/qgis-template.github.io).
+### QGIS News Feed submission access
+
+Local user groups can request access to the [QGIS News Feed system](https://feed.qgis.org), which allows you to submit news entries (such as events, crowdfunding campaigns, meetups, or announcements) that will appear in the QGIS news section once approved by moderators. This is an excellent way to share your group's activities with the global QGIS community.
+
+### Template for local country domain qgis.xx
+
+For local country domain, if you do not wish to host and design your website from scratch, you can use the template provided at [https://github.com/qgis/qgis-template.github.io](https://github.com/qgis/qgis-template.github.io).
 
 {{< content-end >}}

--- a/content/community/organisation.md
+++ b/content/community/organisation.md
@@ -82,13 +82,13 @@ QGIS.ORG Böschacherstrasse 10a CH-8624 Grüt (Gossau ZH)
 *   Nyall Dawson \[since 5.2020\]
     
 
-### Country Voting Members
+### Voting Members
 
-According to our statutes, for each country user group that is formed, that group will select a QGIS Country User Group Voting Member to represent their interests. These voting members are listed [here]({{< ref "/community/groups.md" >}}) . Please email [trademark@qgis.org](mailto:trademark@qgis.org) if you have registered a new country user group, or have changed your user group representative.
+According to our statutes, for each user group that is formed, that group will select a QGIS User Group Voting Member to represent their interests. These voting members are listed [here]({{< ref "/community/groups.md" >}}) . Please email [trademark@qgis.org](mailto:trademark@qgis.org) if you have registered a new user group, or have changed your user group representative.
 
 ### Community Voting Members
 
-According to our statutes, one member from the broader community can be elected for each country voting member. The following list includes the current community voting members:
+According to our statutes, one member from the broader community can be elected for each voting member. The following list includes the current community voting members:
 
 *   Martin Dobias, Slovakia
     

--- a/content/community/organisation/guidelines.md
+++ b/content/community/organisation/guidelines.md
@@ -28,11 +28,11 @@ QGIS trademarks, service marks, logos and designs, as well as other works of aut
 
 These Guidelines should be followed along with all QGIS’s rules and policies, posted on QGIS.ORG website or otherwise.
 
-## Country User Groups
+## User Groups
 
-QGIS.ORG permits official [QGIS country user groups]({{< ref "/community/groups" >}}), to modify the QGIS logo and use the modified QGIS logo for non-commercial communications and projects. This permission is subject to continued compliance with these Guidelines, QGIS Trademark Guidelines and all other rules and policies. QGIS reserves the right to cancel or change this permission at any time at its sole discretion. If you would like to use a modified version of the QGIS logo, please submit your artwork for approval at trademark@qgis.org. Upon approval, you will receive a license agreement to sign before you may begin using the artwork.
+QGIS.ORG permits official [QGIS user groups]({{< ref "/community/groups" >}}), to modify the QGIS logo and use the modified QGIS logo for non-commercial communications and projects. This permission is subject to continued compliance with these Guidelines, QGIS Trademark Guidelines and all other rules and policies. QGIS reserves the right to cancel or change this permission at any time at its sole discretion. If you would like to use a modified version of the QGIS logo, please submit your artwork for approval at trademark@qgis.org. Upon approval, you will receive a license agreement to sign before you may begin using the artwork.
 
-QGIS.ORG also permits official country user groups, to register a QGIS Top Level Domain (e.g. qgis.ch, qgis.dk etc.) according to the rules further down in this document.
+QGIS.ORG also permits official user groups, to register a QGIS Top Level Domain (e.g. qgis.ch, qgis.dk etc.) according to the rules further down in this document.
 
 ## Examples of use that do not require permission
 

--- a/content/community/organisation/guidelines.md
+++ b/content/community/organisation/guidelines.md
@@ -108,7 +108,7 @@ When referring to QGIS please do not undermine the validity of the main QGIS pro
         
     3.  **Exceptions**:
         
-        *   QGIS.ORG Country voting members should use their country TLD (QGIS.ch, QGIS.dk, …)
+        *   QGIS.ORG voting members should use their country TLD (QGIS.ch, QGIS.dk, …)
             
         *   Non-commercial projects can use qgis.xxxxx (qgis.tutorials would fall into this category if the tutorials are free) but should ask for permission before registering the domain. QGIS.ORG may register the domain and point it to the name servers provided by the requestor or instruct the requestor to do so.
 

--- a/playwright/ci-test/tests/fixtures/community-page.ts
+++ b/playwright/ci-test/tests/fixtures/community-page.ts
@@ -166,7 +166,6 @@ export class CommunityPage {
                 "Former PSC Members",
                 "Voting members",
                 "Honorable Voting Members",
-                "Country Voting Members",
                 "Community Voting Members",
                 "Release Management",
                 "Packaging Team",

--- a/playwright/ci-test/tests/fixtures/community-page.ts
+++ b/playwright/ci-test/tests/fixtures/community-page.ts
@@ -199,7 +199,7 @@ export class CommunityPage {
             page: "Brand Guidelines",
             texts: [
                 "QGIS Trademark and brand guidelines",
-                "Country User Groups",
+                "User Groups",
                 "Examples of use that do not require permission",
                 "Examples of use requiring permission",
                 "Prohibited Trademark uses",


### PR DESCRIPTION
Closes #742 

## Changes summary

* Replaced all instances of "Country User Group(s)" and "Country Voting Member(s)" with "User Group(s)" and "Voting Member(s)" across the website.

* Expanded the section on website resources for local user groups:
    * including instructions for using QGIS.org subdomain hosting: https://github.com/qgis/QGIS-User-Group-Website
    * submitting news to the QGIS News Feed, 
    * and using a website template for local domains.

<img width="1489" height="826" alt="image" src="https://github.com/user-attachments/assets/cd7d8db9-0abc-47c9-9376-3112597c0734" />

## Requirements:

- https://github.com/qgis/qgis-uni-navigation/pull/25: Allow customising logo/url in the navigation menu so user groups can use their own.

<img width="1514" height="1143" alt="image" src="https://github.com/user-attachments/assets/5f959a90-211f-4b6a-a790-f4e8ad056b24" />
