### PR TITLE
Update Oslandia's author names

### DIFF
--- a/data/contributors/organizations.json
+++ b/data/contributors/organizations.json
@@ -447,13 +447,13 @@
     "members": [
       {
         "username": "pblottiere",
-        "author_names": "Paul Blottière",
+        "author_names": "Paul Blottière,Paul Blottiere",
         "from": "2016-01-01",
         "to": "2019-06-28"
       },
       {
         "username": "troopa81",
-        "author_names": "Julien Cabièces",
+        "author_names": "Julien Cabièces,Julien Cabieces,oslandia",
         "from": "2018-06-01",
         "to": null
       },
@@ -471,13 +471,13 @@
       },
       {
         "username": "koyaani",
-        "author_names": "Antoine Facchini",
+        "author_names": "Antoine Facchini,Antoine",
         "from": "2021-12-01",
         "to": "2023-04-30"
       },
       {
         "username": "Benoitdm-oslandia",
-        "author_names": "Benoit De Mezzo",
+        "author_names": "Benoit De Mezzo,bdm-oslandia,benoitdm-oslandia,Benoit D.-M. - oslandia",
         "from": "2020-05-01",
         "to": null
       },
@@ -489,25 +489,25 @@
       },
       {
         "username": "vmora",
-        "author_names": "Vincent Mora",
+        "author_names": "Vincent Mora,vmora",
         "from": "2013-01-01",
         "to": "2020-11-01"
       },
       {
         "username": "obrix",
-        "author_names": "Bertrand Rix",
+        "author_names": "Bertrand Rix,obrix",
         "from": "2020-01-01",
         "to": "2020-10-28"
       },
       {
         "username": "SebastienPeillet",
-        "author_names": "Sébastien Peillet",
+        "author_names": "Sébastien Peillet,speillet,Peillet Sebastien",
         "from": "2019-09-01",
         "to": "2021-07-30"
       },
       {
         "username": "bblanc",
-        "author_names": "Benoit Blanc",
+        "author_names": "Benoit Blanc,Benoît Blanc",
         "from": "2020-03-01",
         "to": null
       },
@@ -525,7 +525,7 @@
       },
       {
         "username": "peppsac",
-        "author_names": "Pierre-Éric Pelloux-Prayer",
+        "author_names": "Pierre-Éric Pelloux-Prayer,Pierre-Eric Pelloux-Prayer,pierre-eric",
         "from": "2016-11-01",
         "to": "2019-04-05"
       },
@@ -546,6 +546,24 @@
         "author_names": "Éric Lemoine",
         "from": "2017-01-01",
         "to": "2020-01-01"
+      },
+      {
+        "username": "florentfougeres",
+        "author_names": "Florent Fougères,Florent Fougeres",
+        "from": "2023-01-01",
+        "to": null
+      },
+      {
+        "username": "jmkerloch",
+        "author_names": "jmkerloch,Jean-Marie Kerloch,Jean Marie Kerloch",
+        "from": "2021-11-01",
+        "to": null
+      },
+      {
+        "username": "Guts",
+        "author_names": "GeoJulien,Julien Moura,GeoJulien,Julien",
+        "from": "2020-11-01",
+        "to": null
       }
     ],
     "contributions": {

--- a/data/contributors/organizations.json
+++ b/data/contributors/organizations.json
@@ -453,7 +453,7 @@
       },
       {
         "username": "troopa81",
-        "author_names": "Julien Cabièces,Julien Cabieces,oslandia",
+        "author_names": "Julien Cabièces,Julien Cabieces",
         "from": "2018-06-01",
         "to": null
       },

--- a/data/contributors/organizations.json
+++ b/data/contributors/organizations.json
@@ -489,13 +489,13 @@
       },
       {
         "username": "vmora",
-        "author_names": "Vincent Mora,vmora",
+        "author_names": "Vincent Mora",
         "from": "2013-01-01",
         "to": "2020-11-01"
       },
       {
         "username": "obrix",
-        "author_names": "Bertrand Rix,obrix",
+        "author_names": "Bertrand Rix",
         "from": "2020-01-01",
         "to": "2020-10-28"
       },


### PR DESCRIPTION
Given the script only analyzes author names and does not take github handles into account, this is a fix for Oslandia's authors names.
