### PR TITLE
Add application guidelines for Supporting Contributors recognition

### DIFF
--- a/content/community/contributors/application-guidelines.md
+++ b/content/community/contributors/application-guidelines.md
@@ -1,0 +1,181 @@
+---
+type: "page"
+title: "Supporting Contributors Application Guidelines"
+subtitle: ""
+draft: false
+HasBanner: false
+sidebar: true
+---
+
+{{< content-start >}}
+
+{{< rich-box-start icon="📋" layoutClass="tips">}}
+{{< rich-content-start themeClass="coloring-1" >}}
+## About Supporting Contributors Recognition
+
+The QGIS Supporting Contributors program recognizes individuals and organizations whose valuable contributions to QGIS extend beyond code commits. This includes community support, documentation, translation, event organization, outreach, and other behind-the-scenes efforts that make QGIS thrive.
+
+If you've been actively supporting the QGIS community, we encourage you to apply for recognition!
+
+<div style="text-align:center;">
+  <a href="https://forms.gle/wZr4EfCjqPWGaoq37" class="button is-success">
+    🚀 Apply Now
+  </a>
+</div>
+
+{{< rich-content-end >}}
+{{< rich-box-end >}}
+
+---
+
+## Who Can Apply?
+
+Both **individuals** and **organizations** who contribute to QGIS in non-code capacities are eligible to apply.
+
+### Eligible Contribution Types
+
+- ✅ **QGIS Project Steering Committee** member
+- ✅ **Open Days** organizer or active participant
+- ✅ **Country User Group Coordinator**
+- ✅ **Changelog Contributor**
+- ✅ **User Conference Organiser**
+- ✅ **Translator** (documentation, interface, website)
+- ✅ **Plugins Reviewer**
+- ✅ **Documentation Writer**
+- ✅ **Issue Tracker Moderator**
+
+---
+
+## Application Requirements
+
+### Required Information
+
+#### For All Applicants:
+
+1. **Email Address** *(required)*
+   - Your contact email
+
+2. **Type** *(required)*
+   - Choose: Individual or Organisation
+
+3. **Name** *(required)*
+   - Your full name (individuals) or organization name
+
+4. **Website/Profile Link**
+   - Your personal website, LinkedIn, or organization website
+
+5. **Profile Image** *(required)*
+   - **Format:** PNG only
+   - **Size:** Maximum 150×150 pixels, max 1 MB
+   - **Quality:** Clear, professional photo or logo
+
+#### Activity Details:
+
+6. **Start Date** *(required)*
+   - When did you begin your QGIS community activities?
+
+7. **End Date**
+   - If applicable. Leave blank if still active.
+   - ⚠️ **Note:** 3 years after the end date, your entry will be moved to the 'archived' section. You can request to update your profile if you become active again.
+
+8. **Type of Activities** *(required)*
+   - Select all that apply (see eligible types above)
+
+9. **Description of Contribution** *(required)*
+   - **Maximum:** 500 characters (keep it concise!)
+   - Describe your activities and impact on the QGIS community
+   - Include specific examples where possible
+
+#### Optional Location Information:
+
+10. **Latitude & Longitude**
+    - Provide coordinates for a generalized location (not your home/office!)
+    - Use decimal degrees format (e.g., 51.5074, -0.1278)
+
+---
+
+## For Organizations
+
+If you're applying as an organization, also include:
+
+- **Organization Name**
+- **Logo** (PNG format, 150×150px maximum)
+- Brief description of your organization's QGIS involvement
+- Types of support you provide to the community
+
+---
+
+## What Happens After You Apply?
+
+### Review Process
+
+1. **Submission:** Complete the [application form](https://forms.gle/wZr4EfCjqPWGaoq37)
+2. **Review:** The QGIS Project Steering Committee (PSC) reviews all submissions
+3. **Timeline:** Reviews are conducted **monthly**
+4. **Notification:** You'll be contacted about your application status
+5. **Publication:** Approved contributors appear on the [Supporting Contributors page](/community/contributors/supporting/)
+
+### Approval Criteria
+
+Your application will be evaluated based on:
+
+- ✅ **Relevance:** Activities directly support QGIS or its community
+- ✅ **Impact:** Contributions have meaningful benefit to users or the project
+- ✅ **Duration:** Sustained engagement (not one-off efforts)
+- ✅ **Verifiability:** Activities can be confirmed (links, references, etc.)
+- ✅ **Community Spirit:** Aligns with QGIS values and code of conduct
+
+---
+
+## Tips for a Successful Application
+
+### Writing Your Description
+
+{{< rich-box-start icon="💡" layoutClass="tips">}}
+{{< rich-content-start themeClass="coloring-2" >}}
+
+**DO:**
+- Be specific about your contributions
+- Mention concrete outcomes or metrics when possible
+- Highlight ongoing or sustained efforts
+- Include relevant links or references
+
+Example: **"Coordinated monthly QGIS meetups in Berlin since 2022 with 20-40 attendees. Organized the 2024 QGIS User Conference Germany with 150+ participants. Maintain German QGIS documentation translations."**
+
+**DON'T:**
+- Be vague or generic
+- Exaggerate your contributions
+- Include work that's already recognized via code commits
+- Exceed the 500 character limit
+
+{{< rich-content-end >}}
+{{< rich-box-end >}}
+
+### Image Requirements
+
+- Use a professional headshot or clear logo
+- Ensure good contrast and visibility at small sizes
+- Optimize file size (under 1 MB)
+- Use static images format only (PNG, JPG)
+- Exactly 150×150 pixels works best
+
+### Location Privacy
+
+⚠️ **Important:** If sharing your location, use a **generalized point** (city center, region) rather than your exact home or workplace address.
+
+
+## After Approval
+
+Once approved, you'll appear on the [Supporting Contributors page](/community/contributors/supporting/)
+
+---
+
+<div style="text-align:center; margin-top: 3rem;">
+  <h2>Ready to Apply?</h2>
+  <p>Share your story and get the recognition you deserve!</p>
+  <a href="https://forms.gle/wZr4EfCjqPWGaoq37" class="button is-success">
+    📝 Submit Application
+  </a>
+</div>
+
+{{< content-end >}}

--- a/content/community/contributors/supporting.md
+++ b/content/community/contributors/supporting.md
@@ -14,9 +14,12 @@ sidebar: true
 {{< rich-box-start icon="🙋" layoutClass="tips">}}
 {{< rich-content-start themeClass="coloring-1" >}}
 ## Supporting Contributors
-This list highlights individuals and organizations whose valuable contributions to QGIS may not be reflected in commit histories—such as community support, outreach, or other behind-the-scenes efforts. If you believe your work should be recognized here, please fill out the [QGIS Supporting Contributors Application form](https://forms.gle/wZr4EfCjqPWGaoq37). The QGIS Project Steering Committee (PSC) reviews submissions on a monthly basis.
+This list highlights individuals and organizations whose valuable contributions to QGIS may not be reflected in commit histories—such as community support, outreach, or other behind-the-scenes efforts. If you believe your work should be recognized here, please review our [application guidelines](/community/contributors/application-guidelines/) and fill out the [QGIS Supporting Contributors Application form](https://forms.gle/wZr4EfCjqPWGaoq37). The QGIS Project Steering Committee (PSC) reviews submissions on a monthly basis.
 
 <div style="text-align:center;">
+  <a href="/community/contributors/application-guidelines/" class="button is-success is-outlined" style="margin-right: 1rem;">
+    📋 Application Guidelines
+  </a>
   <a href="https://forms.gle/wZr4EfCjqPWGaoq37" class="button is-success">
     🚀 Submit Your Contribution
   </a>


### PR DESCRIPTION
Closes #802 

- Added a new page for Supporting contributors application guidelines 
- Add a link to the guidelines on the supporting contributors list

<img width="1024" height="281" alt="image" src="https://github.com/user-attachments/assets/1e6a4912-048c-4a4c-b62c-50dd7036aa95" />


https://github.com/user-attachments/assets/7d50af2b-2afb-4eab-b995-f2cdcd49a0d1


See https://github.com/qgis/QGIS-Website/commit/e5a8a86264f6ebb2d98ba090ce406ca2c80b28d6 for the full changes.
