### PR TITLE
use conference.qgis.org everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 > - [members.qgis.org](https://members.qgis.org) ([GitHub: QGIS-Members-Website](https://github.com/qgis/QGIS-Members-Website)) – QGIS Sustaining Members Portal
 > - [certification.qgis.org](https://certification.qgis.org) ([GitHub: QGIS-Certification-Website](https://github.com/qgis/QGIS-Certification-Website)) – QGIS Certification Programme Platform
 > - [changelog.qgis.org](https://changelog.qgis.org) ([GitHub: QGIS-Changelog-Website](https://github.com/qgis/QGIS-Changelog-Website)) – QGIS Changelog Manager
-> - [uc2025.qgis.org](https://uc.qgis.org) ([GitHub: QGIS-UC-Website](https://github.com/qgis/QGIS-UC-Website)) – QGIS User Conference Website
+> - [conference.qgis.org](https://conference.qgis.org) ([GitHub: QGIS-UC-Website](https://github.com/qgis/QGIS-UC-Website)) – QGIS User Conference Website
 
 ![-----------------------------------------------------](./img/green-gradient.png)
 

--- a/config.toml
+++ b/config.toml
@@ -282,8 +282,8 @@ sectionPagesMenu = 'main'
 
 [[menu.main]]
   parent = "Meetings"
-  name = "QGIS UC 2025"
-  url = "https://uc2025.qgis.org/"
+  name = "QGIS Conference"
+  url = "https://conference.qgis.org/"
   weight = 185
 
 [[menu.main]]

--- a/content/community/organisation/meetings.md
+++ b/content/community/organisation/meetings.md
@@ -20,7 +20,7 @@ Since 2009 the QGIS community has been organizing developer and user meetings ar
 When: 5-7 October 2026
 Where: Switzerland
 
-{{< button class = "is-primary1" link = "https://uc2026.qgis.org/" text = "Learn more" >}} 
+{{< button class = "is-primary1" link = "https://conference.qgis.org/" text = "Learn more" >}} 
 
 {{< rich-content-end >}}
 {{< rich-right-start >}}

--- a/themes/hugo-bulma-blocks-theme/layouts/partials/explore.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/partials/explore.html
@@ -23,7 +23,7 @@
             </p>
             <ul class="arrow-ul is-size-5 has-text-weight-bold">
                 <li>
-                    Join our <a href="https://uc2025.qgis.org/">annual international conference</a>
+                    Join our <a href="https://conference.qgis.org/">annual international conference</a>
                     to explore the future of GIS.
                 </li>
                 <li>Find local user groups and support providers.</li>


### PR DESCRIPTION
Make the qgis.org website link to conference.qgis.org everywhere so we reduce edits needed on the main website.
this requires creating the conference.qgis.org to redirect to uc202x.qgis.org as discussed with @timlinux