### PR TITLE
Update S3 downloads workflow to run hourly instead of daily

### DIFF
--- a/.github/workflows/update-s3-downloads.yml
+++ b/.github/workflows/update-s3-downloads.yml
@@ -2,9 +2,9 @@
 name: 📦 Update S3 Downloads
 
 on:
-  # Run daily at 2 AM UTC
+  # Run hourly
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 * * * *'
   
   # Allow manual trigger
   workflow_dispatch:


### PR DESCRIPTION
This will prevent us from waiting a whole day for the next download listing update to be triggered.

Currently, this workflow takes about 1m30s per day, and this will increase it to ~ 30mins per day.