### PR TITLE
Update roles for contributor Ujaval Gandhi

### DIFF
--- a/data/contributors/supporting.json
+++ b/data/contributors/supporting.json
@@ -55,7 +55,7 @@
     "link": "https://spatialthoughts.com/",
     "roles": [
       "Open Days",
-      "Documentation Writer"
+      "QGIS Educator / Trainer"
     ],
     "contribution_description": "I create and maintain hundreds of hours of free and open learning materials on QGIS. Have been working with the community and regularly give talks at conferences and open days to promote adoption of QGIS. I also support the project financially through my academy - Spatial Thoughts - which is a sustaining member and a QGIS certifying organization.",
     "start_date": "2008-06-01",


### PR DESCRIPTION
Small update to replace "Documentation Write" with a more appropriate "QGIS Educator / Trainer" role.