### PR TITLE
Replace URL for QGIS Colombia

### DIFF
--- a/content/community/groups.md
+++ b/content/community/groups.md
@@ -70,7 +70,7 @@ Reviewer: Tim Sutton
 
 {{< rich-list listLink="https://qgis.es/" icon="🇪🇸" layoutClass="half" listTitle="Association of QGIS users in Spain" listSubtitle="Contact: Carlos López Quintanilla" >}}
 
-{{< rich-list listLink="https://qgisusers.co" icon="🇨🇴" layoutClass="half" listTitle="Grupo de Usuarios QGIS Colombia" listSubtitle="Contact: Germán Carrillo" >}}
+{{< rich-list listLink="https://github.com/qgisco" icon="🇨🇴" layoutClass="half" listTitle="Grupo de Usuarios QGIS Colombia" listSubtitle="Contact: Germán Carrillo" >}}
 
 
 ### Removed 2018


### PR DESCRIPTION
The old domain hasn't been renewed since some years, and it's currently redirecting to unrelated and suspicious websites.

I propose replacing it with the User Group's GitHub account, where we shared our materials (courses, workshops, presentations, etc.) and which has a link to our Twitter account, with all the news of the User Group at that time.


Fixes partially #887, thanks @agiudiceandrea for reporting it!