### PR TITLE
Refactor tab content for QGIS documentation

### DIFF
--- a/content/resources/hub.md
+++ b/content/resources/hub.md
@@ -33,9 +33,9 @@ You will find documentation for every QGIS Long Term Release (LTR) on the respec
 
 {{< language-select >}}
 
-{{< tabs tab1="QGIS |ltrversion|" tab2="QGIS |version|" tab3="QGIS testing (>|version|)" tab4="Archived releases" tab5="Data protection">}}
+<!--{{< tabs tab1="QGIS |ltrversion|" tab2="QGIS |version|" tab3="QGIS testing (>|version|)" tab4="Archived releases" tab5="Data protection">}} -->
 
-<!--{{< tabs tab1="QGIS |ltrversion|" tab2="QGIS testing (>|ltrversion|)" tab3="Archived releases" tab4="Data protection">}} -->
+{{< tabs tab1="QGIS |ltrversion|" tab2="QGIS testing (>|ltrversion|)" tab3="Archived releases" tab4="Data protection">}}
 
 {{< tab-content-start tab="1" >}}
 **For users (QGIS {{< param "ltrversion" >}}):**
@@ -74,7 +74,7 @@ You will find documentation for every QGIS Long Term Release (LTR) on the respec
 {{< tab-content-end >}}
 
 
-{{< tab-content-start tab="2" >}}
+<!--{{< tab-content-start tab="2" >}}
 **For users (QGIS {{< param "version" >}}):**
 
 {{< rich-list listLink="https://docs.qgis.org/|version|/<lang>/docs/user_manual"  layoutClass="inline-block link-with-language" listTitle="Desktop User Guide — <lang>" >}}
@@ -108,10 +108,10 @@ You will find documentation for every QGIS Long Term Release (LTR) on the respec
 
 {{< rich-list listLink="https://docs.qgis.org/|version|/zip"  layoutClass="inline-block" listTitle="HTML zip of the manuals" >}}
 
-{{< tab-content-end >}}
+{{< tab-content-end >}} -->
 
 
-{{< tab-content-start tab="3" >}}
+{{< tab-content-start tab="2" >}}
 
 We are still updating (not translating yet) the documentation for releases newer than QGIS {{< param "ltrversion" >}}. We call this version 'QGIS Testing' and the documentation can be found here: 
 
@@ -148,8 +148,10 @@ We are still updating (not translating yet) the documentation for releases newer
 
 {{< tab-content-end >}}
 
-{{< tab-content-start tab="4" >}}
+{{< tab-content-start tab="3" >}}
 
+
+{{< rich-list listLink="https://docs.qgis.org/3.40/<lang>"  layoutClass="inline-block link-with-language" listTitle="QGIS 3.40 Documentation — <lang>" >}}
 
 {{< rich-list listLink="https://docs.qgis.org/3.34/<lang>"  layoutClass="inline-block link-with-language" listTitle="QGIS 3.34 Documentation — <lang>" >}}
 
@@ -167,7 +169,7 @@ We are still updating (not translating yet) the documentation for releases newer
 
 {{< tab-content-end >}}
 
-{{< tab-content-start tab="5" >}}
+{{< tab-content-start tab="4" >}}
 
 In line with GDPR and related data protection regulations, we provide the following documentation:
 


### PR DESCRIPTION
There is no 4.0 documentation so testing and 4.0 tabs both point to testing docs.
Also 3.40 is now outdated