### PR TITLE
Run S3 downloads update job only in QGIS repo

### DIFF
--- a/.github/workflows/update-s3-downloads.yml
+++ b/.github/workflows/update-s3-downloads.yml
@@ -13,7 +13,8 @@ jobs:
   update-s3-downloads:
     name: Update S3 Downloads List
     runs-on: ubuntu-latest
-    
+    if: github.repository_owner == 'qgis'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
to avoid contributors being hourly fled with failing reports if not disabled locally. See https://github.com/DelazJ/QGIS-Website/actions/workflows/update-s3-downloads.yml