### PR TITLE
Swap Stripe and Payrexx donation widgets in download and thank you pages

### DIFF
--- a/content/community/involve.md
+++ b/content/community/involve.md
@@ -113,8 +113,8 @@ We welcome two types of financial contributions:
 
 {{< rich-content-end >}}
 {{< rich-right-start >}}  
-<!-- {{< stripe-widget otherMethods="true">}} -->
-{{< payrexx-widget otherMethods="true">}}
+{{< stripe-widget otherMethods="true">}}
+<!-- {{< payrexx-widget otherMethods="true">}} -->
 {{< rich-right-end >}}
 {{< rich-box-end >}}
 

--- a/content/download/index.md
+++ b/content/download/index.md
@@ -30,8 +30,8 @@ Donations to QGIS might be tax-deductible in some countries. Please refer to you
 
 {{< rich-content-end >}}
 {{< rich-right-start mode="html" >}}
-<!-- {{< stripe-widget otherMethods="true" skipToDownload="true" >}} -->
-{{< payrexx-widget otherMethods="true" skipToDownload="true" >}}
+{{< stripe-widget otherMethods="true" skipToDownload="true" >}}
+<!-- {{< payrexx-widget otherMethods="true" skipToDownload="true" >}} -->
 {{< rich-right-end >}}
 {{< rich-box-end >}}
 

--- a/content/funding/donate.md
+++ b/content/funding/donate.md
@@ -30,25 +30,25 @@ Create a recurring sustaining membership.
 
 
 {{< rich-box-start layoutClass="has-right mt-6" mode="html" >}}
-{{< rich-content-start themeClass="coloring-1" >}}
-## Payrexx Donation
+{{< rich-content-start themeClass="coloring-2" >}}
+## Stripe Donation
 
-We use the [payrexx.com](https://payrexx.com) service to receive credit card donations. Note that the payment fees at Payrexx are substantially lower than at Paypal - so we would appreciate it, if you could use Payrexx instead of PayPal. No signup needed.
+We use the [stripe.com](https://stripe.com) service to receive credit card donations. Note that the payment fees at Stripe are substantially lower than at Paypal - so we would appreciate it, if you could use Stripe instead of PayPal. No signup needed.
 {{< rich-content-end >}}
 {{< rich-right-start >}}  
-{{< payrexx-widget >}}
+{{< stripe-widget >}}
 {{< rich-right-end >}}
 {{< rich-box-end >}}
 
 
 {{< rich-box-start layoutClass="has-right mt-6" mode="html" >}}
 {{< rich-content-start themeClass="coloring-1" >}}
-## Stripe Donation
+## Payrexx Donation
 
-We also use the [stripe.com](https://stripe.com) service to receive credit card donations. Note that the payment fees at Stripe are substantially lower than at Paypal - so we would appreciate it, if you could use [Payrexx](#payrexx-donation) or Stripe instead of PayPal. No signup needed.
+We also use the [payrexx.com](https://payrexx.com) service to receive credit card donations. Note that the payment fees at Payrexx are substantially lower than at Paypal - so we would appreciate it, if you could use [Stripe](#stripe-donation) or Payrexx instead of PayPal. No signup needed.
 {{< rich-content-end >}}
 {{< rich-right-start >}}  
-{{< stripe-widget >}}
+{{< payrexx-widget >}}
 {{< rich-right-end >}}
 {{< rich-box-end >}}
 

--- a/content/thank-you/index.md
+++ b/content/thank-you/index.md
@@ -39,8 +39,8 @@ Our very best regards!
 
 {{< rich-content-end >}}
 {{< rich-right-start mode="html" >}}
-<!-- {{< stripe-widget otherMethods="true" alreadyDonated="true">}} -->
-{{< payrexx-widget otherMethods="true" alreadyDonated="true">}}
+{{< stripe-widget otherMethods="true" alreadyDonated="true">}}
+<!-- {{< payrexx-widget otherMethods="true" alreadyDonated="true">}} -->
 {{< rich-right-end >}}
 {{< rich-box-end >}}
 

--- a/playwright/ci-test/tests/fixtures/community-page.ts
+++ b/playwright/ci-test/tests/fixtures/community-page.ts
@@ -256,11 +256,11 @@ export class CommunityPage {
         this.sustainDonateLink = this.page.getByRole("link", {
             name: "Sustain & Donate",
         });
-        this.submitButton = this.page.locator("#payrexx-submit-button");
+        this.submitButton = this.page.locator("#stripe-submit-button");
         this.otherMethodsInfoLink = this.page.getByRole("link", {
             name: "Other methods, more info",
         });
-        this.currencyInput = this.page.locator("#payrexx-currency");
+        this.currencyInput = this.page.locator("#stripe-currency");
         this.workflowCertificationImg = this.page.getByRole("img", {
             name: "Workflow Certification",
         });

--- a/playwright/ci-test/tests/fixtures/download-page.ts
+++ b/playwright/ci-test/tests/fixtures/download-page.ts
@@ -12,11 +12,11 @@ export class DownloadPage {
 
     constructor(public readonly page: Page) {
         this.beforeDownloadText = this.page.getByText("Before download starts");
-        this.submitButton = this.page.locator("#payrexx-submit-button");
+        this.submitButton = this.page.locator("#stripe-submit-button");
         this.otherMethodsLink = this.page.getByRole("link", {
             name: "Other methods, more info",
         });
-        this.currencyInput = this.page.locator("#payrexx-currency");
+        this.currencyInput = this.page.locator("#stripe-currency");
         this.skipDownloadButton = this.page.getByRole("button", {
             name: "Skip it and go to download",
         });

--- a/playwright/ci-test/tests/fixtures/funding-page.ts
+++ b/playwright/ci-test/tests/fixtures/funding-page.ts
@@ -17,7 +17,7 @@ export class FundingPage {
             page: "Donate",
             texts: [
                 "Sustaining Membership",
-                "Payrexx Donation",
+                "Stripe Donation",
                 "Bank transfer",
                 "Paypal Donation",
                 "Your support is vital to keep QGIS improving",
@@ -58,8 +58,8 @@ export class FundingPage {
     ];
     constructor(public readonly page: Page) {
         this.pageBody = this.page.locator("body");
-        this.submitButton = this.page.locator("#payrexx-submit-button");
-        this.currencyInput = this.page.locator("#payrexx-currency");
+        this.submitButton = this.page.locator("#stripe-submit-button");
+        this.currencyInput = this.page.locator("#stripe-currency");
         this.donateButton = this.page.getByRole("button", { name: "Donate" });
         this.becomeSustainingMemberLink = this.page.getByRole("link", {
             name: "Become a Sustaining Member",


### PR DESCRIPTION
Closes #897 

Cc @timlinux and @andreasneumann 
This will make Stripe the preferred donation platform in the following pages while keeping Payrexx as the second preference:

- https://qgis.org/funding/donate/
- https://qgis.org/download/
- https://qgis.org/download/thank-you/
- https://qgis.org/community/involve/- 

This depends on https://github.com/qgis/QGIS-Hugo-Website-Theme/pull/6.