### PR TITLE
Update faq.md

### DIFF
--- a/content/resources/support/faq.md
+++ b/content/resources/support/faq.md
@@ -113,12 +113,32 @@ Linux). Please read [Building QGIS from source](https://github.com/qgis/QGIS/blo
 
 If you need to cite QGIS in your work or for an assignment, please use the citation style that would be most helpful:
 
-**QGIS Digital Object Identifier (DOI)**
+Here are some choices to cite the overall QGIS software project, a specific QGIS version being used used, or QGIS documentation to allow reproducibility:
 
+**The QGIS project as an evolving software project, independent of a specific software release, by Digital Object Identifier (concept DOI)**
 
-DOI: [10.5281/zenodo.6139224](https://doi.org/10.5281/zenodo.6139224)
+Use the concept DOI [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6139224.svg)](https://doi.org/10.5281/zenodo.6139224)  when 
+- referring to the QGIS software in general (e.g., in introductions or background sections)
+- describing workflows where the exact version is not critical
+- citing QGIS as a long-term research tool or infrastructure
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6139224.svg)](https://doi.org/10.5281/zenodo.6139224)
+The concept DOI will always resolve to the latest version of QGIS and provide a stable reference to the software project over time.
+
+**Specific QGIS software releases by Digital Object Identifier (version DOI)**
+
+Each QGIS release since release 3.22.4 (2022) has its own version DOI identifying a precise, archived snapshot of the software (e.g., a specific software release). All version DOI are linked to the concept DOI of the QGIS project.
+
+Please refer to the QGIS Zenodo Landing Page ([QGIS Zenodo Landing Page](https://zenodo.org/search?q=parent.id%3A6139224&f=allversions%3Atrue&l=list&p=1&s=10&sort=version)) for all specific version DOI.
+
+- QGIS 4.0.1      [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19401447.svg)](https://doi.org/10.5281/zenodo.19401447)
+- QGIS 4.0.0      [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18889261.svg)](https://doi.org/10.5281/zenodo.18889261)
+- QGIS 3.44.9     [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19401570.svg)](https://doi.org/10.5281/zenodo.19401570)     
+- QGIS 3.44.8     [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18889145.svg)](https://doi.org/10.5281/zenodo.18889145)
+- QGIS 3.44.7     [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18268584.svg)](https://doi.org/10.5281/zenodo.18268584)
+- QGIS 3.40.15    [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18268583.svg)](https://doi.org/10.5281/zenodo.18268583)
+- QGIS 3.40.14    [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17987821.svg)](https://doi.org/10.5281/zenodo.17987821)
+  
+- QGIS 3.44 LTR   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15705458.svg)](https://doi.org/10.5281/zenodo.15705458)
 
 
 **Cite the QGIS project in general**
@@ -188,6 +208,8 @@ Example BibTeX entry:
   author = {Anita Graser and Tim Sutton and Marco Bernasocchi}
 }
 ```
+
+
 
 ### I created a map with QGIS, do I have to mention QGIS?
 

--- a/content/resources/support/faq.md
+++ b/content/resources/support/faq.md
@@ -130,13 +130,7 @@ Each QGIS release since release 3.22.4 (2022) has its own version DOI identifyin
 
 Please refer to the QGIS Zenodo Landing Page ([QGIS Zenodo Landing Page](https://zenodo.org/search?q=parent.id%3A6139224&f=allversions%3Atrue&l=list&p=1&s=10&sort=version)) for all specific version DOI.
 
-- QGIS 4.0.1      [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19401447.svg)](https://doi.org/10.5281/zenodo.19401447)
 - QGIS 4.0.0      [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18889261.svg)](https://doi.org/10.5281/zenodo.18889261)
-- QGIS 3.44.9     [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19401570.svg)](https://doi.org/10.5281/zenodo.19401570)     
-- QGIS 3.44.8     [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18889145.svg)](https://doi.org/10.5281/zenodo.18889145)
-- QGIS 3.44.7     [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18268584.svg)](https://doi.org/10.5281/zenodo.18268584)
-- QGIS 3.40.15    [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18268583.svg)](https://doi.org/10.5281/zenodo.18268583)
-- QGIS 3.40.14    [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17987821.svg)](https://doi.org/10.5281/zenodo.17987821)
   
 - QGIS 3.44 LTR   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15705458.svg)](https://doi.org/10.5281/zenodo.15705458)
 


### PR DESCRIPTION
The section about citation of QGIS by Digital Object Identifier (DOI) was extended, to accomodate information about citation of the overall codebase by concept DOI and specific QGIS releases by version DOI.