### PR TITLE
Fix None crashes and numeric version comparison in update-schedule.py

### DIFF
--- a/scripts/update-schedule.py
+++ b/scripts/update-schedule.py
@@ -45,6 +45,11 @@ def fetch_magnet(download_url):
         return resp.read().decode("utf-8").strip()
 
 
+def version_tuple(version):
+    """Parse a dotted version like "3.40" into a tuple of ints for correct numeric comparison."""
+    return tuple(int(part) for part in version.split("."))
+
+
 url = "https://docs.google.com/spreadsheets/u/1/d/1MOIjwon5eDI04DG6rX_HwucZkW1fxFJ0b_yB0xYETOE/export?format=csv&id=1MOIjwon5eDI04DG6rX_HwucZkW1fxFJ0b_yB0xYETOE&gid=1982100417#"
 
 cal = Calendar()
@@ -245,8 +250,8 @@ for v, n in {ltr_version: ltr_name, lr_version: lr_name}.items():
     rn = re.search("^set\\(RELEASE_NAME \"(.*)\"\\)$", cm, re.MULTILINE).group(1)
     assert n == rn, f"Expected {n}, found {rn}"  # nosec: W291
 
-assert lr_version.split(".") > ltr_version.split("."), f"LR {lr_version} not higher than {ltr_version}"  # nosec: W291
-assert devversion.split(".") > lr_version.split("."), f"DEV {devversion} not higher than {lr_version}"  # nosec: W291
+assert version_tuple(lr_version) > version_tuple(ltr_version), f"LR {lr_version} not higher than {ltr_version}"  # nosec: W291
+assert version_tuple(devversion) > version_tuple(lr_version), f"DEV {devversion} not higher than {lr_version}"  # nosec: W291
 
 shortver = "".join(lr_version.split(".")[:2])
 for f in [
@@ -277,8 +282,8 @@ with open("data/conf.json", "w") as f:
         "nextversion": nextversion,
         "nextfreezedate": f_date.strftime('%Y-%m-%d %H:%M:%S UTC') if f_date is not None else None,
         "nextreleasedate": nr_date.strftime('%Y-%m-%d %H:%M:%S UTC') if nr_date is not None else None,
-        "nextpointreleasedate": pr_date.strftime('%Y-%m-%d %H:%M:%S UTC'),
-        "infeaturefreeze": f_date < now,
+        "nextpointreleasedate": pr_date.strftime('%Y-%m-%d %H:%M:%S UTC') if pr_date is not None else None,
+        "infeaturefreeze": f_date < now if f_date is not None else None,
         "next_ltr_version": next_ltr_version,
         "next_lr_version": next_lr_version,
 


### PR DESCRIPTION
### Summary

This PR improves the robustness of `scripts/update-schedule.py`.

* Prevents crashes when the release schedule contains no upcoming point release or freeze date by handling missing values safely.
* Replaces lexicographic version comparisons with numeric tuple comparisons to ensure correct ordering of future two-digit minor versions (for example, `3.10` vs `3.2`).

There is no functional change for current release versions, but these fixes prevent failures on incomplete schedules and avoid incorrect version ordering in the future.
