### PR TITLE
Fix update-schedule.py f-strings that fail to parse on Python 3.10

### DIFF
--- a/scripts/update-schedule.py
+++ b/scripts/update-schedule.py
@@ -50,6 +50,11 @@ def version_tuple(version):
     return tuple(int(part) for part in version.split("."))
 
 
+def macos_version(version):
+    """Convert a dotted version like "3.44.9" to the macOS dmg form "3_44_9"."""
+    return version.replace(".", "_")
+
+
 url = "https://docs.google.com/spreadsheets/u/1/d/1MOIjwon5eDI04DG6rX_HwucZkW1fxFJ0b_yB0xYETOE/export?format=csv&id=1MOIjwon5eDI04DG6rX_HwucZkW1fxFJ0b_yB0xYETOE&gid=1982100417#"
 
 cal = Calendar()
@@ -300,10 +305,10 @@ with open("data/conf.json", "w") as f:
         "ltr_sha": f"https://download.qgis.org/downloads/QGIS-OSGeo4W-{ltr_version}-{ltr_binary}.sha256sum",
         "ltr_grids_msi": f"https://download.qgis.org/downloads/QGIS-Grids-OSGeo4W-{ltr_version}-{ltr_binary}.msi",
         "ltr_grids_sha": f"https://download.qgis.org/downloads/QGIS-Grids-OSGeo4W-{ltr_version}-{ltr_binary}.sha256sum",
-        "ltr_dmg": f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{"_".join(ltr_version.split("."))}.dmg",
-        "ltr_dmg_sha": f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{"_".join(ltr_version.split("."))}.sha256sum",
-        "lr_dmg": f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{"_".join(lr_version.split("."))}.dmg",
-        "lr_dmg_sha": f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{"_".join(lr_version.split("."))}.sha256sum",
+        "ltr_dmg": f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_version)}.dmg",
+        "ltr_dmg_sha": f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_version)}.sha256sum",
+        "lr_dmg": f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_version)}.dmg",
+        "lr_dmg_sha": f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_version)}.sha256sum",
         "weekly_msi": "/downloads/windows/weekly/",
 
         # torrent / magnet links (torrent hosted on dl1.qgis.org, magnet from server-generated sidecar)
@@ -319,12 +324,12 @@ with open("data/conf.json", "w") as f:
         "ltr_grids_msi_torrent": torrent_url(f"https://download.qgis.org/downloads/QGIS-Grids-OSGeo4W-{ltr_version}-{ltr_binary}.msi"),
         "ltr_grids_msi_magnet": fetch_magnet(f"https://download.qgis.org/downloads/QGIS-Grids-OSGeo4W-{ltr_version}-{ltr_binary}.msi"),
         "ltr_grids_msi_meta4": meta4_url(f"https://download.qgis.org/downloads/QGIS-Grids-OSGeo4W-{ltr_version}-{ltr_binary}.msi"),
-        "lr_dmg_torrent": torrent_url(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{'_'.join(lr_version.split('.'))}.dmg"),
-        "lr_dmg_magnet": fetch_magnet(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{'_'.join(lr_version.split('.'))}.dmg"),
-        "lr_dmg_meta4": meta4_url(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{'_'.join(lr_version.split('.'))}.dmg"),
-        "ltr_dmg_torrent": torrent_url(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{'_'.join(ltr_version.split('.'))}.dmg"),
-        "ltr_dmg_magnet": fetch_magnet(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{'_'.join(ltr_version.split('.'))}.dmg"),
-        "ltr_dmg_meta4": meta4_url(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{'_'.join(ltr_version.split('.'))}.dmg"),
+        "lr_dmg_torrent": torrent_url(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_version)}.dmg"),
+        "lr_dmg_magnet": fetch_magnet(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_version)}.dmg"),
+        "lr_dmg_meta4": meta4_url(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_version)}.dmg"),
+        "ltr_dmg_torrent": torrent_url(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_version)}.dmg"),
+        "ltr_dmg_magnet": fetch_magnet(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_version)}.dmg"),
+        "ltr_dmg_meta4": meta4_url(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_version)}.dmg"),
     }, f, indent=4)
 
 o = open("content/schedule.ics", "wb")


### PR DESCRIPTION
### Summary of the Fixes

`scripts/update-schedule.py` fails to parse on the project's declared Python version. The `ltr_dmg`, `ltr_dmg_sha`, `lr_dmg` and `lr_dmg_sha` download URLs use an f-string with a double-quoted expression nested inside a double-quoted string, for example:

```python
f"...qgis_ltr_final-{ "_".join(ltr_version.split(".")) }.dmg"
```

Reusing the same quote character inside an f-string expression is only valid on Python 3.12+ (PEP 701). The repo targets Python 3.10 (`.python-version`, `Pipfile`), where the entire module raises `SyntaxError: f-string: expecting '}'` and cannot run.

Switched the inner quotes to single quotes, matching the torrent / magnet / meta4 block immediately below that already does exactly this. Verified the module compiles under Python 3.10.