### PR TITLE
Remove broken OGC conformance report links

### DIFF
--- a/content/resources/testing.md
+++ b/content/resources/testing.md
@@ -28,19 +28,4 @@ See [Unit testing](https://docs.qgis.org/testing/en/docs/developers_guide/unitte
 
 See the [OGC conformance testing documentation](https://docs.qgis.org/testing/en/docs/developers_guide/ogcconformancetesting.html) for more information and notes on how to run these tests yourself.
 
-{{< button
-class = "is-primary1 is-small"
-link = "http://test.qgis.org/ogc_cite"
-text = "OGC Cite tests" >}}
-
-{{< button
-class = "is-primary1 is-small"
-link = "http://test.qgis.org/ogc_cite/wms_130/latest/report.html"
-text = "WMS 1.3.0 Tests" >}}
-
-{{< button
-class = "is-primary1 is-small"
-link = "http://test.qgis.org/ogc_cite/wfs_110/latest/report.html"
-text = "WFS 1.1.0 Tests" >}}
-
 {{< content-end >}}


### PR DESCRIPTION
## Summary
- Remove three OGC conformance report buttons that currently resolve to 404 pages.
- Keep the existing OGC conformance testing documentation link as the active reference.

Fixes #994

## Testing
- Verified the removed `test.qgis.org/ogc_cite` links redirect to 404 pages.
- Verified the PR diff only changes `content/resources/testing.md`.