### PR TITLE
Rebase before committing in the scheduled data-update workflows

### DIFF
--- a/.github/workflows/check-commercial-support-links.yml
+++ b/.github/workflows/check-commercial-support-links.yml
@@ -40,16 +40,10 @@ jobs:
     - name: '⬇️ Pull latest changes before commit'
       run: |
         cd ./qgis-website
-        # Other scheduled jobs commit to main too, and one of them may have
-        # pushed while this job was running. Refresh our checkout first so the
-        # commit below is not rejected as a non fast forward push.
-        if ! git diff --quiet || ! git diff --cached --quiet; then
-          git stash push -u -m "Auto stash before pull"
-          git pull --rebase origin main || echo "Nothing new to pull"
-          git stash pop || echo "Nothing to pop"
-        else
-          git pull --rebase origin main || echo "Nothing new to pull"
-        fi
+        # Another scheduled job may have pushed to main while this one ran.
+        # Rebase on top of it first (autostash tucks the generated files
+        # aside) so the commit below is a fast forward.
+        git pull --rebase --autostash origin main
 
     - name: '✉️ Commit'
       uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/check-commercial-support-links.yml
+++ b/.github/workflows/check-commercial-support-links.yml
@@ -37,6 +37,20 @@ jobs:
         cd ./qgis-website
         pipenv run ./scripts/sanitize_commercial_supports.py
 
+    - name: '⬇️ Pull latest changes before commit'
+      run: |
+        cd ./qgis-website
+        # Other scheduled jobs commit to main too, and one of them may have
+        # pushed while this job was running. Refresh our checkout first so the
+        # commit below is not rejected as a non fast forward push.
+        if ! git diff --quiet || ! git diff --cached --quiet; then
+          git stash push -u -m "Auto stash before pull"
+          git pull --rebase origin main || echo "Nothing new to pull"
+          git stash pop || echo "Nothing to pop"
+        else
+          git pull --rebase origin main || echo "Nothing new to pull"
+        fi
+
     - name: '✉️ Commit'
       uses: stefanzweifel/git-auto-commit-action@v7
       with:

--- a/.github/workflows/tx-coverage.yml
+++ b/.github/workflows/tx-coverage.yml
@@ -58,8 +58,8 @@ jobs:
               git commit -m "Update translation coverage [skip ci]"
             fi
             # Rebase onto anything that landed on main while we were running,
-            # then push so the update is not rejected.
-            git pull --rebase origin main || echo "Nothing new to pull"
+            # then push. A real rebase failure should fail the job.
+            git pull --rebase --autostash origin main
             git push
           else
             echo "No coverage changes"

--- a/.github/workflows/tx-coverage.yml
+++ b/.github/workflows/tx-coverage.yml
@@ -57,6 +57,9 @@ jobs:
             else
               git commit -m "Update translation coverage [skip ci]"
             fi
+            # Rebase onto anything that landed on main while we were running,
+            # then push so the update is not rejected.
+            git pull --rebase origin main || echo "Nothing new to pull"
             git push
           else
             echo "No coverage changes"

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -55,6 +55,20 @@ jobs:
         pipenv run python scripts/match_commercial_contributors.py
         echo "Commercial support matching completed"
 
+    - name: '⬇️ Pull latest changes before commit'
+      run: |
+        cd ./qgis-website
+        # Other scheduled jobs commit to main too, and one of them may have
+        # pushed while this job was running. Refresh our checkout first so the
+        # commit below is not rejected as a non fast forward push.
+        if ! git diff --quiet || ! git diff --cached --quiet; then
+          git stash push -u -m "Auto stash before pull"
+          git pull --rebase origin main || echo "Nothing new to pull"
+          git stash pop || echo "Nothing to pop"
+        else
+          git pull --rebase origin main || echo "Nothing new to pull"
+        fi
+
     - name: '✉️ Commit and push changes'
       uses: stefanzweifel/git-auto-commit-action@v7
       with:

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -58,16 +58,10 @@ jobs:
     - name: '⬇️ Pull latest changes before commit'
       run: |
         cd ./qgis-website
-        # Other scheduled jobs commit to main too, and one of them may have
-        # pushed while this job was running. Refresh our checkout first so the
-        # commit below is not rejected as a non fast forward push.
-        if ! git diff --quiet || ! git diff --cached --quiet; then
-          git stash push -u -m "Auto stash before pull"
-          git pull --rebase origin main || echo "Nothing new to pull"
-          git stash pop || echo "Nothing to pop"
-        else
-          git pull --rebase origin main || echo "Nothing new to pull"
-        fi
+        # Another scheduled job may have pushed to main while this one ran.
+        # Rebase on top of it first (autostash tucks the generated files
+        # aside) so the commit below is a fast forward.
+        git pull --rebase --autostash origin main
 
     - name: '✉️ Commit and push changes'
       uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/update-donors.yml
+++ b/.github/workflows/update-donors.yml
@@ -46,16 +46,10 @@ jobs:
     - name: '⬇️ Pull latest changes before commit'
       run: |
         cd ./qgis-website
-        # Other scheduled jobs commit to main too, and one of them may have
-        # pushed while this job was running. Refresh our checkout first so the
-        # commit below is not rejected as a non fast forward push.
-        if ! git diff --quiet || ! git diff --cached --quiet; then
-          git stash push -u -m "Auto stash before pull"
-          git pull --rebase origin main || echo "Nothing new to pull"
-          git stash pop || echo "Nothing to pop"
-        else
-          git pull --rebase origin main || echo "Nothing new to pull"
-        fi
+        # Another scheduled job may have pushed to main while this one ran.
+        # Rebase on top of it first (autostash tucks the generated files
+        # aside) so the commit below is a fast forward.
+        git pull --rebase --autostash origin main
 
     - name: '✉️ Commit'
       uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/update-donors.yml
+++ b/.github/workflows/update-donors.yml
@@ -43,6 +43,20 @@ jobs:
         pipenv run ./scripts/update_donors.py
         pipenv run ./scripts/update_payrexx_donors.py
 
+    - name: '⬇️ Pull latest changes before commit'
+      run: |
+        cd ./qgis-website
+        # Other scheduled jobs commit to main too, and one of them may have
+        # pushed while this job was running. Refresh our checkout first so the
+        # commit below is not rejected as a non fast forward push.
+        if ! git diff --quiet || ! git diff --cached --quiet; then
+          git stash push -u -m "Auto stash before pull"
+          git pull --rebase origin main || echo "Nothing new to pull"
+          git stash pop || echo "Nothing to pop"
+        else
+          git pull --rebase origin main || echo "Nothing new to pull"
+        fi
+
     - name: '✉️ Commit'
       uses: stefanzweifel/git-auto-commit-action@v7
       with:

--- a/.github/workflows/update-feeds.yml
+++ b/.github/workflows/update-feeds.yml
@@ -60,16 +60,10 @@ jobs:
     - name: '⬇️ Pull latest changes before commit'
       run: |
         cd ./qgis-website
-        # Stash any changes, pull with rebase, then pop the stash
-        if ! git diff --quiet || ! git diff --cached --quiet; then
-          echo "Changes detected, stashing..."
-          git stash push -u -m "Auto-stash before pull"
-          git pull --rebase origin main || echo "No upstream changes to pull"
-          git stash pop || echo "No stash to pop or conflicts resolved"
-        else
-          echo "No changes to stash, pulling directly..."
-          git pull --rebase origin main || echo "No upstream changes to pull"
-        fi
+        # Another scheduled job may have pushed to main while this one ran.
+        # Rebase on top of it first (autostash tucks the generated files
+        # aside) so the commit below is a fast forward.
+        git pull --rebase --autostash origin main
 
     - name: '✉️ Commit'
       uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/update-gh-sponsors.yml
+++ b/.github/workflows/update-gh-sponsors.yml
@@ -31,6 +31,19 @@ jobs:
               </div>
             </a>
     
+      - name: '⬇️ Pull latest changes before commit'
+        run: |
+          # Other scheduled jobs commit to main too, and one of them may have
+          # pushed while this job was running. Refresh our checkout first so the
+          # commit below is not rejected as a non fast forward push.
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            git stash push -u -m "Auto stash before pull"
+            git pull --rebase origin main || echo "Nothing new to pull"
+            git stash pop || echo "Nothing to pop"
+          else
+            git pull --rebase origin main || echo "Nothing new to pull"
+          fi
+
       - name: '✉️ Commit'
         uses: stefanzweifel/git-auto-commit-action@v7
         with:

--- a/.github/workflows/update-gh-sponsors.yml
+++ b/.github/workflows/update-gh-sponsors.yml
@@ -33,16 +33,10 @@ jobs:
     
       - name: '⬇️ Pull latest changes before commit'
         run: |
-          # Other scheduled jobs commit to main too, and one of them may have
-          # pushed while this job was running. Refresh our checkout first so the
-          # commit below is not rejected as a non fast forward push.
-          if ! git diff --quiet || ! git diff --cached --quiet; then
-            git stash push -u -m "Auto stash before pull"
-            git pull --rebase origin main || echo "Nothing new to pull"
-            git stash pop || echo "Nothing to pop"
-          else
-            git pull --rebase origin main || echo "Nothing new to pull"
-          fi
+          # Another scheduled job may have pushed to main while this one ran.
+          # Rebase on top of it first (autostash tucks the generated file
+          # aside) so the commit below is a fast forward.
+          git pull --rebase --autostash origin main
 
       - name: '✉️ Commit'
         uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/update-s3-downloads.yml
+++ b/.github/workflows/update-s3-downloads.yml
@@ -55,6 +55,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/downloads/
           git commit -m "🤖 Update S3 downloads listing [skip ci]"
+          # Rebase onto anything that landed on main while we were running,
+          # then push so the update is not rejected.
+          git pull --rebase origin main || echo "Nothing new to pull"
           git push
       
       - name: Report status

--- a/.github/workflows/update-s3-downloads.yml
+++ b/.github/workflows/update-s3-downloads.yml
@@ -56,8 +56,8 @@ jobs:
           git add data/downloads/
           git commit -m "🤖 Update S3 downloads listing [skip ci]"
           # Rebase onto anything that landed on main while we were running,
-          # then push so the update is not rejected.
-          git pull --rebase origin main || echo "Nothing new to pull"
+          # then push. A real rebase failure should fail the job.
+          git pull --rebase --autostash origin main
           git push
       
       - name: Report status


### PR DESCRIPTION
### Summary of the Fixes

Several scheduled workflows commit generated data to `main` on overlapping schedules (contributors, donors, sponsors, S3 downloads, Transifex coverage, commercial support links). When two run close together, the second one's `git push` is rejected as a non fast forward. That is the failure behind the periodic `update-contributors` run failures, where the "Commit and push changes" step ends with `! [rejected] main -> main (non-fast-forward)` after `origin/main` moved while the job was running.

`update-feeds.yml` already handles this by pulling with `--rebase` before it commits. This applies the same pattern to the workflows that were missing it:

- **update-contributors, update-donors, check-commercial-support-links, update-gh-sponsors** (which use `git-auto-commit-action`): a step that stashes, runs `git pull --rebase origin main`, then pops, right before the commit step.
- **update-s3-downloads, tx-coverage** (which push with raw git): a `git pull --rebase origin main` between the `git commit` and the `git push`.

No behaviour change beyond making the push resilient to commits that land on `main` while the job is running.