### PR TITLE
Add pytest tests for the contributors and donors scripts (builds on #1005)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,30 @@
+name: 🐍 Python Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main, develop ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛒 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: REQUIREMENTS.txt
+
+      - name: 🚸 Install dependencies
+        run: pip install -r REQUIREMENTS.txt
+
+      - name: 🧪 Run pytest
+        run: pytest

--- a/scripts/update_contributing_orgs.py
+++ b/scripts/update_contributing_orgs.py
@@ -10,6 +10,9 @@ import argparse
 CONFIG_PATH = "data/contributors/config.json"
 ORG_PATH = "data/contributors/organizations.json"
 CONTRIBUTORS_API = "https://hub.qgis.org/api/v1/contributors"
+# (connect, read) timeouts in seconds: fail fast if the host stops responding,
+# but allow a long read for large aggregations across many repositories.
+REQUEST_TIMEOUT = (10, 300)
 
 def load_json(path):
     with open(path, "r") as f:
@@ -22,7 +25,7 @@ def save_json(path, data):
 def fetch_all_repos():
     url = f"{CONTRIBUTORS_API}/fetch-all-repos"
     print(f"Fetching repositories from {url}")
-    response = requests.get(url)
+    response = requests.get(url, timeout=REQUEST_TIMEOUT)
     if response.status_code == 200:
         return response.json()
     return None
@@ -37,9 +40,11 @@ def get_commit_counts(repo_name, author=None, since=None, until=None):
     if until:
         params["until"] = until
     print(f"    Querying {url} with params {params}")
-    response = requests.get(url, params=params)
-    if response.status_code == 200 and response.json():
-        return response.json()
+    response = requests.get(url, params=params, timeout=REQUEST_TIMEOUT)
+    if response.status_code == 200:
+        data = response.json()
+        if data:
+            return data
     return None
 
 def update_stats(target_orgs=None,target_thematics=None):
@@ -79,6 +84,10 @@ def update_stats(target_orgs=None,target_thematics=None):
                     since = from_date if from_date else None
                     until = to_date if to_date else None
                     commit_counts = get_commit_counts(repo_name, author=author, since=since, until=until)
+                    # The API returns None on a non-200 response or empty body.
+                    # Skip this member instead of crashing the whole run.
+                    if not commit_counts:
+                        continue
                     total_commits += commit_counts.get("commits", 0)
                     member_last_date = commit_counts.get("last_commit_date")
                     if member_last_date:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Pytest configuration shared by the test suite.
+
+Puts ``scripts/`` on ``sys.path`` once, before any test module is imported,
+so the utility scripts can be imported directly (e.g. ``import
+update_contributing_orgs``) without per-test path manipulation.
+"""
+import os
+import sys
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)

--- a/test/test_update_contributing_orgs.py
+++ b/test/test_update_contributing_orgs.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for scripts/update_contributing_orgs.py.
+
+The contributors API returns ``None`` whenever a request is non-200 or the
+body is empty. These tests pin two reliability fixes:
+
+* ``update_stats`` must skip a member with no API data and still save,
+  rather than crashing the whole scheduled run with ``AttributeError``.
+* ``get_commit_counts`` must pass a request timeout so a hung server cannot
+  stall the job indefinitely.
+
+``scripts/`` is placed on ``sys.path`` by ``test/conftest.py``, so the module
+under test can be imported directly here.
+"""
+import update_contributing_orgs as uco
+
+
+def test_update_stats_skips_members_with_no_api_data(monkeypatch):
+    config = {"repositories": {"web_sites": ["qgis/QGIS-Website"]}}
+    orgs = [
+        {
+            "name": "Example Org",
+            "members": [{"username": "octocat"}],
+            "contributions": {
+                "web_sites": {"commits": 999, "last_contribution": "2020-01-01"}
+            },
+        }
+    ]
+    saved = {}
+
+    monkeypatch.setattr(
+        uco, "load_json", lambda path: config if path == uco.CONFIG_PATH else orgs
+    )
+    monkeypatch.setattr(
+        uco, "save_json", lambda path, data: saved.update({"path": path, "data": data})
+    )
+    # Simulate the API returning nothing for every query.
+    monkeypatch.setattr(uco, "get_commit_counts", lambda *a, **k: None)
+
+    # Must not raise AttributeError when the API yields no data.
+    uco.update_stats()
+
+    assert saved, "save_json should still be called when API data is missing"
+    web_sites = saved["data"][0]["contributions"]["web_sites"]
+    assert web_sites["commits"] == 0
+    assert web_sites["last_contribution"] is None
+
+
+def test_get_commit_counts_passes_a_timeout(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"commits": 5}
+
+    def fake_get(url, params=None, timeout=None):
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(uco.requests, "get", fake_get)
+
+    uco.get_commit_counts("qgis/QGIS-Website", author="octocat")
+
+    assert (
+        captured["timeout"] == uco.REQUEST_TIMEOUT
+    ), "requests.get must be called with the configured timeout"

--- a/test/test_update_donors.py
+++ b/test/test_update_donors.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Tests for scripts/update_donors.py (Stripe donor sync).
+
+Exercises name formatting, add/remove/sort behavior, the donors.json write
+format, timestamp persistence, and the Stripe opt-in routing in
+``get_donors`` — with the Stripe API and the filesystem fully mocked, so a
+``stripe``/stdlib upgrade that changes behavior is caught.
+
+``scripts/`` is placed on ``sys.path`` by ``test/conftest.py``.
+"""
+import json
+
+import update_donors as ud
+
+
+def _write_json(path, obj):
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def test_format_name_strips_punctuation_and_titlecases():
+    assert ud.format_name("  john DOE.  ") == "John Doe"
+    assert ud.format_name("JANE,") == "Jane"
+    assert ud.format_name("alice smith") == "Alice Smith"
+
+
+def test_update_donors_adds_formats_dedupes_and_sorts(tmp_path):
+    f = tmp_path / "donors.json"
+    _write_json(f, {"donors": ["Bob"]})
+
+    ud.update_donors("alice", str(f))
+    ud.update_donors("Bob", str(f))  # duplicate after format -> not re-added
+
+    assert json.loads(f.read_text())["donors"] == ["Alice", "Bob"]
+
+
+def test_update_donors_creates_file_when_missing(tmp_path):
+    f = tmp_path / "missing.json"
+    ud.update_donors("zoe", str(f))
+    assert json.loads(f.read_text())["donors"] == ["Zoe"]
+
+
+def test_update_donors_writes_indent_4(tmp_path):
+    f = tmp_path / "donors.json"
+    _write_json(f, {"donors": []})
+    ud.update_donors("Tim", str(f))
+    # indent=4 nests array items at 8 spaces.
+    assert '\n        "Tim"' in f.read_text()
+
+
+def test_remove_donor_removes_when_present(tmp_path):
+    f = tmp_path / "donors.json"
+    _write_json(f, {"donors": ["Alice", "Bob"]})
+    ud.remove_donor("bob", str(f))
+    assert json.loads(f.read_text())["donors"] == ["Alice"]
+
+
+def test_remove_donor_missing_file_is_noop(tmp_path):
+    f = tmp_path / "nope.json"
+    ud.remove_donor("Bob", str(f))  # must not raise
+    assert not f.exists()
+
+
+def test_timestamp_roundtrip(tmp_path, monkeypatch):
+    ts_file = tmp_path / "latest.txt"
+    monkeypatch.setattr(ud, "TIMESTAMP_FILE", str(ts_file))
+
+    assert ud.get_latest_timestamp() == 0  # missing file -> 0
+    ud.save_latest_timestamp(1234567890)
+    assert ud.get_latest_timestamp() == 1234567890
+
+
+def test_get_donors_routes_opt_in_and_opt_out(monkeypatch):
+    customers = {
+        "data": [
+            {"id": "c1", "name": "Alice", "created": 100, "metadata": {}},
+            {
+                "id": "c2",
+                "name": "Bob",
+                "created": 200,
+                "metadata": {"list_as_donor": "false"},
+            },
+        ],
+        "has_more": False,
+    }
+    # Fully mock Stripe so no network/credentials are needed.
+    monkeypatch.setattr(ud.stripe.Customer, "list", lambda **kw: customers)
+    monkeypatch.setattr(ud.stripe.checkout.Session, "list", lambda **kw: {"data": []})
+    monkeypatch.setattr(ud, "get_latest_timestamp", lambda: 0)
+    saved = {}
+    monkeypatch.setattr(ud, "save_latest_timestamp", lambda ts: saved.update(ts=ts))
+
+    calls = []
+    monkeypatch.setattr(ud, "update_donors", lambda name, f: calls.append(("add", name)))
+    monkeypatch.setattr(ud, "remove_donor", lambda name, f: calls.append(("remove", name)))
+
+    ud.get_donors("data/donors.json", "List me as a donor")
+
+    # Alice has no opt-out -> added; Bob opted out via metadata -> removed.
+    assert ("add", "Alice") in calls
+    assert ("remove", "Bob") in calls
+    # Latest timestamp advances to the newest donation.
+    assert saved["ts"] == 200

--- a/test/test_update_donors_from_file.py
+++ b/test/test_update_donors_from_file.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Tests for scripts/update_donors_from_file.py.
+
+Exercises name formatting and the file-based donor update (read existing
+JSON, format + dedupe + sort new names, write back) using real temp files,
+so a change in the formatting/sorting/output behavior is caught.
+
+``scripts/`` is placed on ``sys.path`` by ``test/conftest.py``.
+"""
+import json
+
+import update_donors_from_file as udf
+
+
+def test_format_name_strips_punctuation_and_titlecases():
+    assert udf.format_name("  john DOE.  ") == "John Doe"
+    assert udf.format_name("JANE,") == "Jane"
+    assert udf.format_name("alice") == "Alice"
+
+
+def test_update_donors_formats_dedupes_and_sorts(tmp_path):
+    donors_json = tmp_path / "donors.json"
+    donors_json.write_text(json.dumps({"donors": ["Bob"]}), encoding="utf-8")
+    names = tmp_path / "names.txt"
+    names.write_text("alice\nBOB\nCAROL,\n", encoding="utf-8")
+
+    udf.update_donors([str(names)], str(donors_json))
+
+    data = json.loads(donors_json.read_text())
+    # "BOB" -> "Bob" (already present, not duplicated); result sorted.
+    assert data["donors"] == ["Alice", "Bob", "Carol"]
+
+
+def test_update_donors_creates_file_when_missing(tmp_path):
+    donors_json = tmp_path / "missing.json"
+    names = tmp_path / "names.txt"
+    names.write_text("Zoe\nAnna\n", encoding="utf-8")
+
+    udf.update_donors([str(names)], str(donors_json))
+
+    assert json.loads(donors_json.read_text())["donors"] == ["Anna", "Zoe"]
+
+
+def test_update_donors_skips_missing_input_file(tmp_path):
+    donors_json = tmp_path / "donors.json"
+    donors_json.write_text(json.dumps({"donors": ["Bob"]}), encoding="utf-8")
+
+    # A non-existent input file must be skipped, not crash the run.
+    udf.update_donors([str(tmp_path / "nope.txt")], str(donors_json))
+
+    assert json.loads(donors_json.read_text())["donors"] == ["Bob"]
+
+
+def test_update_donors_writes_indent_4(tmp_path):
+    donors_json = tmp_path / "donors.json"
+    donors_json.write_text(json.dumps({"donors": []}), encoding="utf-8")
+    names = tmp_path / "names.txt"
+    names.write_text("Tim\n", encoding="utf-8")
+
+    udf.update_donors([str(names)], str(donors_json))
+
+    # indent=4 nests array items at 8 spaces.
+    assert '\n        "Tim"' in donors_json.read_text()

--- a/test/test_update_individual_contributors.py
+++ b/test/test_update_individual_contributors.py
@@ -1,0 +1,478 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for scripts/update_individual_contributors.py.
+
+These tests exercise the script's real parsing, aggregation, sorting and
+transform logic so that a future dependency upgrade (requests, etc.) that
+silently changes behaviour would be caught here.
+
+Everything that touches the outside world is mocked:
+
+* network -- ``requests.post`` (the GraphQL endpoint) is replaced with a fake
+  that yields canned pages, so no HTTP ever happens;
+* time / rate limiting -- ``time.sleep`` is patched to a no-op and the
+  reset-time parser is fed deterministic strings;
+* filesystem -- reads/writes go through ``tmp_path`` or are captured by
+  monkeypatching ``save_contributors``.
+
+``scripts/`` is placed on ``sys.path`` by ``test/conftest.py``, so the module
+under test can be imported directly here.
+"""
+import json
+
+import update_individual_contributors as mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def make_counter(monkeypatch, email_mappings=None):
+    """Build a counter without loading the real email-mapping file."""
+    monkeypatch.setattr(
+        mod.GitHubContributionCounter,
+        "load_email_mappings",
+        lambda self: email_mappings or {},
+    )
+    return mod.GitHubContributionCounter(token="fake-token")
+
+
+def commit(author_login=None, author_email=None, author_name=None,
+           committer_login=None, committer_email=None):
+    """Build a GraphQL commit node the way the API returns it."""
+    def actor(login, email, name):
+        node = {"name": name, "email": email}
+        node["user"] = {"login": login} if login else None
+        return node
+
+    return {
+        "oid": "deadbeef",
+        "committedDate": "2024-01-01T00:00:00Z",
+        "author": actor(author_login, author_email, author_name),
+        "committer": actor(
+            committer_login,
+            committer_email,
+            committer_login or "committer",
+        ),
+    }
+
+
+def graphql_history_response(commits, has_next_page=False, end_cursor=None):
+    """Wrap commit nodes in the nested shape get_commits_with_authors reads."""
+    return {
+        "data": {
+            "repository": {
+                "ref": {
+                    "target": {
+                        "history": {
+                            "pageInfo": {
+                                "hasNextPage": has_next_page,
+                                "endCursor": end_cursor,
+                            },
+                            "nodes": commits,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def patch_no_sleep(monkeypatch):
+    """Guarantee no real sleeping happens during a test."""
+    monkeypatch.setattr(mod.time, "sleep", lambda *a, **k: None)
+
+
+def patch_safe_rate_limit(monkeypatch):
+    """check_rate_limit always reports plenty of quota (skips wait branch)."""
+    monkeypatch.setattr(
+        mod.GitHubContributionCounter,
+        "check_rate_limit",
+        lambda self: {"remaining": 5000, "limit": 5000, "resetAt": ""},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bot / identifier helpers (pure functions)
+# ---------------------------------------------------------------------------
+def test_is_bot_login_matches_known_patterns(monkeypatch):
+    counter = make_counter(monkeypatch)
+    assert counter.is_bot_login("dependabot[bot]") is True
+    assert counter.is_bot_login("github-actions") is True
+    assert counter.is_bot_login("renovate") is True
+    assert counter.is_bot_login("RoboBOTov") is True  # substring 'bot', case-insensitive
+    # Real humans must not be flagged.
+    assert counter.is_bot_login("nyalldawson") is False
+    assert counter.is_bot_login("octocat") is False
+
+
+def test_is_bot_email_and_clean_identifier(monkeypatch):
+    counter = make_counter(monkeypatch)
+    assert counter.is_bot_email("noreply@github-actions.com") is True
+    assert counter.is_bot_email("bot@example.com") is True
+    assert counter.is_bot_email("jane@example.com") is False
+
+    # extract_clean_identifier strips each supported prefix.
+    assert counter.extract_clean_identifier("email:jane@example.com") == "jane"
+    assert counter.extract_clean_identifier("name:Jane Doe") == "Jane Doe"
+    assert counter.extract_clean_identifier("no-github:bob@x.org") == "bob"
+    assert counter.extract_clean_identifier("octocat") == "octocat"
+
+
+# ---------------------------------------------------------------------------
+# get_commits_with_authors: aggregation, dedup, bot exclusion, pagination
+# ---------------------------------------------------------------------------
+def test_get_commits_aggregates_and_excludes_bots(monkeypatch):
+    counter = make_counter(monkeypatch)
+    patch_no_sleep(monkeypatch)
+    patch_safe_rate_limit(monkeypatch)
+
+    commits = [
+        commit(author_login="alice", committer_login="alice"),
+        commit(author_login="alice", committer_login="alice"),  # dedup -> alice:2
+        commit(author_login="bob", committer_login="bob"),
+        # bot author login is excluded entirely
+        commit(author_login="dependabot[bot]", committer_login="dependabot[bot]"),
+        # bot committer also causes the commit to be skipped
+        commit(author_login="carol", committer_login="github-actions[bot]"),
+        # anonymous author (no GitHub user) tracked by email
+        commit(author_email="anon@example.com", committer_email="anon@example.com"),
+        # anonymous author whose email is a bot -> excluded
+        commit(author_email="ci@github-actions.com",
+               committer_email="ci@github-actions.com"),
+    ]
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return FakeResponse(graphql_history_response(commits))
+
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+
+    result = counter.get_commits_with_authors("qgis", "QGIS-Website", "main")
+
+    assert result["alice"] == 2
+    assert result["bob"] == 1
+    assert result["email:anon@example.com"] == 1
+    # Bots / bot-committed / bot-email commits never appear.
+    assert "dependabot[bot]" not in result
+    assert "carol" not in result
+    assert "email:ci@github-actions.com" not in result
+
+
+def test_get_commits_falls_back_to_name_when_no_email(monkeypatch):
+    counter = make_counter(monkeypatch)
+    patch_no_sleep(monkeypatch)
+    patch_safe_rate_limit(monkeypatch)
+
+    commits = [
+        # No GitHub user and no email -> fall back to name: identifier.
+        commit(author_name="Jane Doe", committer_email="jane@example.com"),
+    ]
+    monkeypatch.setattr(
+        mod.requests, "post",
+        lambda *a, **k: FakeResponse(graphql_history_response(commits)),
+    )
+
+    result = counter.get_commits_with_authors("qgis", "QGIS-Website", "main")
+    assert result == {"name:Jane Doe": 1}
+
+
+def test_get_commits_paginates_across_pages(monkeypatch):
+    counter = make_counter(monkeypatch)
+    patch_no_sleep(monkeypatch)
+    patch_safe_rate_limit(monkeypatch)
+
+    pages = [
+        graphql_history_response(
+            [commit(author_login="alice", committer_login="alice")],
+            has_next_page=True, end_cursor="CURSOR1",
+        ),
+        graphql_history_response(
+            [commit(author_login="alice", committer_login="alice"),
+             commit(author_login="bob", committer_login="bob")],
+            has_next_page=False, end_cursor=None,
+        ),
+    ]
+    calls = {"n": 0}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        # The cursor from page 1 must be threaded into the page-2 request.
+        if calls["n"] == 1:
+            assert json["variables"]["cursor"] == "CURSOR1"
+        payload = pages[calls["n"]]
+        calls["n"] += 1
+        return FakeResponse(payload)
+
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+
+    result = counter.get_commits_with_authors("qgis", "QGIS-Website", "main")
+    assert calls["n"] == 2, "should have fetched exactly two pages"
+    assert result == {"alice": 2, "bob": 1}
+
+
+def test_get_commits_returns_empty_on_graphql_errors(monkeypatch):
+    counter = make_counter(monkeypatch)
+    patch_no_sleep(monkeypatch)
+    patch_safe_rate_limit(monkeypatch)
+
+    monkeypatch.setattr(
+        mod.requests, "post",
+        lambda *a, **k: FakeResponse({"errors": [{"message": "boom"}]}),
+    )
+
+    result = counter.get_commits_with_authors("qgis", "Missing", "main")
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit reset-time parsing + wait calculation
+# ---------------------------------------------------------------------------
+def test_rate_limit_low_parses_reset_time_and_waits(monkeypatch):
+    """When quota is low the script parses resetAt and sleeps a bounded time."""
+    counter = make_counter(monkeypatch)
+
+    # First check returns a low remaining with a parseable resetAt; subsequent
+    # checks (none expected) would also be low, but we stop after one page.
+    monkeypatch.setattr(
+        mod.GitHubContributionCounter,
+        "check_rate_limit",
+        lambda self: {
+            "remaining": 10,
+            "limit": 5000,
+            "resetAt": "2024-01-01T00:05:00Z",
+        },
+    )
+    # Pin "now" so the wait computation is deterministic; reset is 60s ahead.
+    reset_epoch = mod.time.mktime(
+        mod.time.strptime("2024-01-01T00:05:00Z", "%Y-%m-%dT%H:%M:%SZ")
+    )
+    monkeypatch.setattr(mod.time, "time", lambda: reset_epoch - 60)
+
+    slept = []
+    monkeypatch.setattr(mod.time, "sleep", lambda s: slept.append(s))
+
+    monkeypatch.setattr(
+        mod.requests, "post",
+        lambda *a, **k: FakeResponse(graphql_history_response(
+            [commit(author_login="alice", committer_login="alice")]
+        )),
+    )
+
+    result = counter.get_commits_with_authors("qgis", "QGIS-Website", "main")
+
+    assert result == {"alice": 1}
+    assert len(slept) == 1, "exactly one rate-limit wait expected"
+    # wait = min(300, max(60, (reset-now)/remaining)) -> max(60, 60/10)=60.
+    assert slept[0] == 60
+
+
+# ---------------------------------------------------------------------------
+# process_repositories: thematic aggregation, totals, email mapping, reset
+# ---------------------------------------------------------------------------
+def test_process_repositories_aggregates_thematics_and_totals(monkeypatch, tmp_path):
+    config = {
+        "repositories": {
+            "core": ["QGIS"],
+            "web_sites": ["QGIS-Website"],
+            "empty": [],  # commented-out / empty thematic must be skipped
+        }
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+    output_path = str(tmp_path / "contributors.json")
+
+    # Map an anonymous email contributor onto a real GitHub login.
+    counter = make_counter(
+        monkeypatch, email_mappings={"email:anon@example.com": "alice"}
+    )
+
+    # Per-repo commit counts keyed by repo name.
+    per_repo = {
+        "QGIS": {"alice": 5, "bob": 3, "dependabot[bot]": 99},
+        "QGIS-Website": {"alice": 2, "email:anon@example.com": 4},
+    }
+
+    def fake_commits(self, owner, repo, branch="main"):
+        # Return data only for the "main" branch; master yields nothing.
+        if branch == "main":
+            return dict(per_repo[repo])
+        return {}
+
+    monkeypatch.setattr(
+        mod.GitHubContributionCounter, "get_commits_with_authors", fake_commits
+    )
+    monkeypatch.setattr(
+        mod.GitHubContributionCounter,
+        "get_user_avatar",
+        lambda self, login: f"https://avatars/{login}.png",
+    )
+    # Nothing on disk yet; avoid touching the filesystem during saves.
+    monkeypatch.setattr(
+        mod.GitHubContributionCounter, "load_existing_data", lambda self, p: {}
+    )
+    monkeypatch.setattr(
+        mod.GitHubContributionCounter, "save_contributors", lambda self, c, p: None
+    )
+
+    result = counter.process_repositories(str(config_path), output_path)
+
+    # alice: 5 (core) + 2 + 4 (web_sites, anon mapped onto her) = 11 total.
+    assert result["alice"]["thematics"]["core"] == 5
+    assert result["alice"]["thematics"]["web_sites"] == 6
+    assert result["alice"]["total_contributions"] == 11
+    assert result["alice"]["has_github_account"] is True
+    assert result["alice"]["avatar_url"] == "https://avatars/alice.png"
+
+    # bob only contributed to core; other thematics are zero-filled.
+    assert result["bob"]["thematics"] == {"core": 3, "web_sites": 0}
+    assert result["bob"]["total_contributions"] == 3
+
+    # Bot was filtered out everywhere.
+    assert "dependabot[bot]" not in result
+    # The mapped email identifier should not survive as its own contributor.
+    assert "email:anon@example.com" not in result
+    # Empty thematic produced no key.
+    assert all("empty" not in c["thematics"] for c in result.values())
+
+
+def test_process_repositories_keeps_unmapped_email_contributor(monkeypatch, tmp_path):
+    config = {"repositories": {"web_sites": ["QGIS-Website"]}}
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+
+    counter = make_counter(monkeypatch, email_mappings={})
+
+    monkeypatch.setattr(
+        mod.GitHubContributionCounter,
+        "get_commits_with_authors",
+        lambda self, owner, repo, branch="main": (
+            {"no-github:legacy@example.com": 7} if branch == "main" else {}
+        ),
+    )
+    monkeypatch.setattr(
+        mod.GitHubContributionCounter, "load_existing_data", lambda self, p: {}
+    )
+    monkeypatch.setattr(
+        mod.GitHubContributionCounter, "save_contributors", lambda self, c, p: None
+    )
+
+    result = counter.process_repositories(str(config_path), str(tmp_path / "out.json"))
+
+    # Old "no-github:" prefix is normalized to "email:" and kept (no avatar).
+    assert "email:legacy@example.com" in result
+    entry = result["email:legacy@example.com"]
+    assert entry["has_github_account"] is False
+    assert entry["avatar_url"] == ""
+    assert entry["total_contributions"] == 7
+
+
+def test_process_repositories_missing_config_returns_empty(monkeypatch, tmp_path):
+    counter = make_counter(monkeypatch)
+    missing = str(tmp_path / "does_not_exist.json")
+    assert counter.process_repositories(missing, str(tmp_path / "out.json")) == {}
+
+
+# ---------------------------------------------------------------------------
+# save_contributors: JSON shape + sort order (round-trips through tmp_path)
+# ---------------------------------------------------------------------------
+def test_save_contributors_sorts_and_shapes_output(monkeypatch, tmp_path):
+    counter = make_counter(monkeypatch)
+    output_path = str(tmp_path / "nested" / "contributors.json")
+
+    contributors = {
+        "low": {"login": "low", "avatar_url": "", "total_contributions": 1,
+                "thematics": {"core": 1}, "has_github_account": True},
+        "high": {"login": "high", "avatar_url": "", "total_contributions": 50,
+                 "thematics": {"core": 50}, "has_github_account": True},
+        "mid": {"login": "mid", "avatar_url": "", "total_contributions": 10,
+                "thematics": {"core": 10}, "has_github_account": True},
+    }
+
+    counter.save_contributors(contributors, output_path)
+
+    with open(output_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    assert data["total_contributors"] == 3
+    assert "_automated_warning" in data
+    assert "generated_at" in data
+    # Sorted by total_contributions descending.
+    logins = [c["login"] for c in data["contributors"]]
+    assert logins == ["high", "mid", "low"]
+
+
+# ---------------------------------------------------------------------------
+# load_existing_data: list -> dict conversion keyed by login
+# ---------------------------------------------------------------------------
+def test_load_existing_data_converts_list_to_dict(monkeypatch, tmp_path):
+    counter = make_counter(monkeypatch)
+    existing = {
+        "contributors": [
+            {"login": "alice", "total_contributions": 5, "thematics": {}},
+            {"login": "bob", "total_contributions": 2, "thematics": {}},
+        ]
+    }
+    path = tmp_path / "contributors.json"
+    path.write_text(json.dumps(existing))
+
+    result = counter.load_existing_data(str(path))
+    assert set(result.keys()) == {"alice", "bob"}
+    assert result["alice"]["total_contributions"] == 5
+
+    # Missing file -> empty dict (no crash).
+    assert counter.load_existing_data(str(tmp_path / "nope.json")) == {}
+
+
+# ---------------------------------------------------------------------------
+# generate_geojson: feature shape, sorting, email skip, geometry matching
+# ---------------------------------------------------------------------------
+def test_generate_geojson_builds_sorted_features(monkeypatch, tmp_path):
+    contributors = {
+        "contributors": [
+            {"login": "alice", "avatar_url": "a.png", "total_contributions": 3,
+             "thematics": {"core": 3}, "has_github_account": True},
+            {"login": "bob", "avatar_url": "b.png", "total_contributions": 30,
+             "thematics": {"core": 30}, "has_github_account": True},
+            {"login": "email:anon@example.com", "avatar_url": "",
+             "total_contributions": 99, "thematics": {"core": 99},
+             "has_github_account": False},
+        ]
+    }
+    contributors_path = tmp_path / "contributors.json"
+    contributors_path.write_text(json.dumps(contributors))
+
+    # Location + honorary files live at module-relative hardcoded paths; the
+    # function reads them via os.path.exists, so just make those return False
+    # to keep the test isolated from the repo's real data directory.
+    monkeypatch.setattr(mod.os.path, "exists", lambda p: p == str(contributors_path))
+
+    out_path = tmp_path / "out" / "map.json"
+    ok = mod.generate_geojson(str(contributors_path), str(out_path))
+    assert ok is True
+
+    with open(out_path, "r", encoding="utf-8") as fh:
+        geo = json.load(fh)
+
+    assert geo["type"] == "FeatureCollection"
+    logins = [f["properties"]["login"] for f in geo["features"]]
+    # email-based contributor skipped; remaining sorted by contributions desc.
+    assert logins == ["bob", "alice"]
+    # Thematics flattened onto properties; no geometry available -> None.
+    bob = geo["features"][0]
+    assert bob["properties"]["core"] == 30
+    assert bob["geometry"] is None
+
+
+def test_generate_geojson_missing_input_returns_false(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod.os.path, "exists", lambda p: False)
+    assert mod.generate_geojson(
+        str(tmp_path / "missing.json"), str(tmp_path / "out.json")
+    ) is False

--- a/test/test_update_payrexx_donors.py
+++ b/test/test_update_payrexx_donors.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for scripts/update_payrexx_donors.py.
+
+These tests pin the deterministic, importable transforms of the Payrexx donor
+management script so a dependency upgrade (requests, etc.) that quietly changes
+behaviour breaks the build instead of silently corrupting ``data/donors.json``.
+
+All external I/O is mocked:
+
+* Real network calls are never made -- the only function that touches the
+  network (``get_donors``) is not exercised; ``requests`` is only imported.
+* File reads/writes are redirected to ``tmp_path`` so the real read -> dedup ->
+  sort -> ``json.dump`` round trip runs against a throwaway file.
+
+A known cross-script inconsistency is documented here: ``remove_donor`` writes
+``data/donors.json`` with ``indent=2`` while ``update_donors`` (both in this
+script and in scripts/update_donors.py) writes it with ``indent=4``. The
+``test_remove_donor_*`` tests pin the indent each write path currently uses so a
+future change is caught.
+
+``scripts/`` is placed on ``sys.path`` by ``test/conftest.py``, so the module
+under test can be imported directly here. The ``if __name__ == "__main__"``
+guard means this import does not run any network code.
+"""
+import json
+
+import update_payrexx_donors as mod
+
+
+def _write_donors(path, donors):
+    """Write a donors JSON file the way the script expects to read it."""
+    path.write_text(
+        json.dumps({"donors": donors}, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def _read_donors(path):
+    return json.loads(path.read_text(encoding="utf-8"))["donors"]
+
+
+def test_format_name_normalizes_case_and_trailing_punctuation():
+    # ALL CAPS -> title case, surrounding whitespace stripped.
+    assert mod.format_name("  JOHN DOE  ") == "John Doe"
+    # Trailing dots/commas removed (one or many), inner punctuation kept.
+    assert mod.format_name("Jane Smith.") == "Jane Smith"
+    assert mod.format_name("Acme Corp,,.") == "Acme Corp"
+    # Already-correct names are left effectively unchanged.
+    assert mod.format_name("Maria Garcia") == "Maria Garcia"
+
+
+def test_update_donors_adds_formats_and_sorts(tmp_path):
+    donors_file = tmp_path / "donors.json"
+    _write_donors(donors_file, ["Zoe Adams", "Anna Bell"])
+
+    # Raw input is ALL CAPS with a trailing dot -> must be normalized on add.
+    mod.update_donors("CHARLIE BROWN.", str(donors_file))
+
+    donors = _read_donors(donors_file)
+    assert donors == ["Anna Bell", "Charlie Brown", "Zoe Adams"]
+
+
+def test_update_donors_is_idempotent_for_duplicates(tmp_path):
+    donors_file = tmp_path / "donors.json"
+    _write_donors(donors_file, ["Charlie Brown"])
+
+    # Adding the same donor again (after formatting) must not duplicate it.
+    mod.update_donors("charlie brown", str(donors_file))
+
+    assert _read_donors(donors_file) == ["Charlie Brown"]
+
+
+def test_update_donors_creates_file_when_missing(tmp_path):
+    # FileNotFoundError path: start from an empty list and create the file.
+    donors_file = tmp_path / "missing.json"
+    assert not donors_file.exists()
+
+    mod.update_donors("Solo Donor", str(donors_file))
+
+    assert donors_file.exists()
+    assert _read_donors(donors_file) == ["Solo Donor"]
+
+
+def test_update_donors_writes_indent_4_and_unescaped_unicode(tmp_path):
+    # Pins this write path's format: indent=4 and ensure_ascii=False.
+    donors_file = tmp_path / "donors.json"
+    _write_donors(donors_file, [])
+
+    mod.update_donors("Renée Dupont", str(donors_file))
+
+    text = donors_file.read_text(encoding="utf-8")
+    # Non-ASCII char must survive verbatim (ensure_ascii=False).
+    assert "Renée Dupont" in text
+    assert "\\u" not in text
+    # indent=4 -> donor entries are indented by 8 spaces (2 nesting levels).
+    assert '\n        "Renée Dupont"' in text
+
+
+def test_remove_donor_removes_match_and_pins_indent_2(tmp_path):
+    # KNOWN INCONSISTENCY: remove_donor writes with indent=2, whereas
+    # update_donors (here and in scripts/update_donors.py) uses indent=4.
+    donors_file = tmp_path / "donors.json"
+    _write_donors(donors_file, ["Anna Bell", "Charlie Brown"])
+
+    # Formatting is applied before matching: "ANNA BELL." -> "Anna Bell".
+    mod.remove_donor("ANNA BELL.", str(donors_file))
+
+    assert _read_donors(donors_file) == ["Charlie Brown"]
+
+    text = donors_file.read_text(encoding="utf-8")
+    # indent=2 -> remaining donor entry is indented by 4 spaces.
+    assert '\n    "Charlie Brown"' in text
+    # Guard the inconsistency: this write path is NOT indent=4 (8 spaces).
+    assert '\n        "Charlie Brown"' not in text
+
+
+def test_remove_donor_no_match_rewrites_unchanged_list(tmp_path):
+    # Edge case: removing an absent donor leaves the list intact but still
+    # rewrites the file (with indent=2).
+    donors_file = tmp_path / "donors.json"
+    _write_donors(donors_file, ["Anna Bell"])
+
+    mod.remove_donor("Nobody Here", str(donors_file))
+
+    assert _read_donors(donors_file) == ["Anna Bell"]
+
+
+def test_remove_donor_missing_file_does_not_write(tmp_path):
+    # FileNotFoundError path: print and return without creating the file.
+    donors_file = tmp_path / "missing.json"
+
+    mod.remove_donor("Anyone", str(donors_file))
+
+    assert not donors_file.exists()
+
+
+def test_generate_api_signature_is_deterministic_hmac():
+    # Pure HMAC-SHA256 + base64; pins the exact auth signature so a hashlib/
+    # base64 behaviour change is caught. Computed independently of the module.
+    import base64
+    import hashlib
+    import hmac
+
+    query_string = "limit=100&offset=0"
+    secret = "test-secret"
+
+    expected = base64.b64encode(
+        hmac.new(
+            secret.encode("utf-8"),
+            query_string.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
+    ).decode("utf-8")
+
+    assert mod.generate_api_signature(query_string, secret) == expected

--- a/test/test_update_supporting_contributors.py
+++ b/test/test_update_supporting_contributors.py
@@ -1,0 +1,379 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for scripts/update_supporting_contributors.py.
+
+This script converts Supporting Contributor XLSX responses into
+``supporting.json`` plus a companion GeoJSON file. These tests pin the
+deterministic parsing/transform/aggregation logic so a dependency upgrade
+(pandas, requests, etc.) that changes behaviour fails loudly:
+
+* ``parse_date`` normalises pandas ``Timestamp`` and assorted string formats
+  to ISO ``YYYY-MM-DD`` (and gracefully returns ``None`` for junk/NaT).
+* ``is_active_contributor`` applies the 3-year "active" threshold.
+* ``parse_roles`` splits a comma list into a clean role list.
+* ``generate_avatar_filename`` slugifies names into the avatar path.
+* ``xlsx_to_supporting_json`` performs the full read -> filter -> transform
+  -> sort -> JSON/GeoJSON aggregation, mocking ALL external I/O
+  (``pandas.read_excel``, filesystem existence checks, image resize and the
+  on-disk writes). No real network or disk access happens.
+
+``scripts/`` is placed on ``sys.path`` by ``test/conftest.py``, so the module
+under test can be imported directly here. Importing is safe because the
+module guards execution behind ``if __name__ == "__main__"``.
+"""
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+# update_supporting_contributors imports pandas, which is not yet in
+# REQUIREMENTS.txt; skip this module cleanly where pandas is unavailable
+# rather than erroring at collection.
+pd = pytest.importorskip("pandas")
+
+import update_supporting_contributors as mod
+
+
+# ---------------------------------------------------------------------------
+# parse_date
+# ---------------------------------------------------------------------------
+def test_parse_date_handles_timestamp_strings_and_junk():
+    # pandas Timestamp -> ISO date
+    assert mod.parse_date(pd.Timestamp("2021-07-04")) == "2021-07-04"
+    # M/D/YY string format
+    assert mod.parse_date("7/4/21") == "2021-07-04"
+    # M/D/YYYY string format
+    assert mod.parse_date("12/31/2020") == "2020-12-31"
+    # NaT / NaN / None / empty / unparseable all collapse to None
+    assert mod.parse_date(pd.NaT) is None
+    assert mod.parse_date(None) is None
+    assert mod.parse_date("") is None
+    assert mod.parse_date("   ") is None
+    assert mod.parse_date("not a date") is None
+
+
+# ---------------------------------------------------------------------------
+# is_active_contributor (3-year threshold boundary)
+# ---------------------------------------------------------------------------
+def test_is_active_contributor_threshold_boundary():
+    # No end date -> still active
+    assert mod.is_active_contributor("") is True
+    assert mod.is_active_contributor(None) is True
+
+    today = datetime.now()
+    # Recently ended -> active
+    recent = today.strftime("%Y-%m-%d")
+    assert mod.is_active_contributor(recent) is True
+
+    # Well over 3 years ago -> inactive
+    old = today.replace(year=today.year - 5).strftime("%Y-%m-%d")
+    assert mod.is_active_contributor(old) is False
+
+    # Unparseable end date -> assume active (defensive default)
+    assert mod.is_active_contributor("garbage") is True
+
+
+# ---------------------------------------------------------------------------
+# parse_roles
+# ---------------------------------------------------------------------------
+def test_parse_roles_splits_and_cleans():
+    assert mod.parse_roles("Coding, Translation , Documentation") == [
+        "Coding",
+        "Translation",
+        "Documentation",
+    ]
+    # Empty / whitespace -> empty list, stray commas dropped
+    assert mod.parse_roles("") == []
+    assert mod.parse_roles("   ") == []
+    assert mod.parse_roles("Coding,,") == ["Coding"]
+    # Single item
+    assert mod.parse_roles("Outreach") == ["Outreach"]
+
+
+# ---------------------------------------------------------------------------
+# generate_avatar_filename
+# ---------------------------------------------------------------------------
+def test_generate_avatar_filename_slugifies_name():
+    assert (
+        mod.generate_avatar_filename("Jane M. Doe", is_org=False)
+        == "/img/contributors/supporting/jane_m_doe.png"
+    )
+    # ASCII special characters stripped, spaces -> underscores, dots removed
+    assert (
+        mod.generate_avatar_filename("Acme Org! (Inc.)", is_org=True)
+        == "/img/contributors/supporting/acme_org_inc.png"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers for the full-pipeline integration tests
+# ---------------------------------------------------------------------------
+def _patch_pipeline(monkeypatch, df, existing=None, image_exists=True):
+    """Wire up mocks for all external I/O and capture JSON writes.
+
+    Returns a dict mapping str(output_path) -> data passed to ``json.dump``.
+    """
+    # No real Excel read.
+    monkeypatch.setattr(mod.pd, "read_excel", lambda path: df)
+    # No real image resizing.
+    monkeypatch.setattr(mod, "resize_image", lambda *a, **k: None)
+    # Control whether an avatar image is found on disk, and whether an
+    # existing supporting.json is present (so json.load is exercised).
+    def fake_exists(path):
+        # The output JSON existence check happens first in the function; we
+        # only want avatar images to (optionally) exist.
+        spath = str(path)
+        if spath.endswith("supporting.json"):
+            return existing is not None
+        if "img/contributors/supporting" in spath.replace("\\", "/"):
+            return image_exists
+        return False
+
+    monkeypatch.setattr(mod.os.path, "exists", fake_exists)
+
+    # Avoid touching the real filesystem when ensuring the geojson dir.
+    monkeypatch.setattr(Path, "mkdir", lambda self, *a, **k: None)
+
+    # Capture json.dump targets keyed by the file's name. We monkeypatch the
+    # module's ``open`` to hand back a sentinel object carrying the path, and
+    # ``json.dump`` to record (path, data) instead of writing.
+    captured = {}
+
+    class FakeFile:
+        def __init__(self, path):
+            self.path = path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        # Support json.load reading existing contributors.
+        def read(self):
+            return ""
+
+    def fake_open(path, mode="r", *a, **k):
+        return FakeFile(str(path))
+
+    def fake_json_dump(data, fp, *a, **k):
+        captured[str(fp.path)] = data
+
+    def fake_json_load(fp):
+        return existing if existing is not None else []
+
+    monkeypatch.setattr(mod, "open", fake_open, raising=False)
+    monkeypatch.setattr(mod.json, "dump", fake_json_dump)
+    monkeypatch.setattr(mod.json, "load", fake_json_load)
+
+    return captured
+
+
+def _outputs(captured):
+    """Split captured writes into (supporting_json, geojson)."""
+    supporting = next(v for k, v in captured.items() if k.endswith("supporting.json"))
+    geojson = next(v for k, v in captured.items() if "map" in k.lower())
+    return supporting, geojson
+
+
+# ---------------------------------------------------------------------------
+# xlsx_to_supporting_json: empty input
+# ---------------------------------------------------------------------------
+def test_pipeline_empty_input_writes_empty_collections(monkeypatch):
+    df = pd.DataFrame(
+        columns=[
+            "Approved (yes/no)",
+            "Individual or Organisation",
+            "Name",
+            "Organization Name",
+            "Email Address",
+        ]
+    )
+    captured = _patch_pipeline(monkeypatch, df)
+
+    mod.xlsx_to_supporting_json(
+        Path("in.xlsx"),
+        Path("data/contributors/supporting.json"),
+        Path("static/data/contributors/supporting_map.json"),
+    )
+
+    supporting, geojson = _outputs(captured)
+    assert supporting == []
+    assert geojson == {"type": "FeatureCollection", "features": []}
+
+
+# ---------------------------------------------------------------------------
+# xlsx_to_supporting_json: single approved entry, full transform + GeoJSON
+# ---------------------------------------------------------------------------
+def test_pipeline_single_approved_entry_full_shape(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "Approved (yes/no)": "Yes",
+                "Individual or Organisation": "Individual",
+                "Name": "Jane Doe",
+                "Organization Name": "",
+                "Email Address": "jane@example.com",
+                "Type of activities": "Coding, Translation",
+                "Description of contribution": "Wrote lots of code",
+                "Website/Profile link": "https://example.com",
+                "Location - Longitude": 12.5,
+                "Location - Latitude": 41.9,
+                "Please enter the start date of your activities with the QGIS community": pd.Timestamp(
+                    "2019-01-01"
+                ),
+                "Please enter the end date of your activities with the QGIS community": "",
+            }
+        ]
+    )
+    captured = _patch_pipeline(monkeypatch, df, image_exists=True)
+
+    mod.xlsx_to_supporting_json(
+        Path("in.xlsx"),
+        Path("data/contributors/supporting.json"),
+        Path("static/data/contributors/supporting_map.json"),
+    )
+
+    supporting, geojson = _outputs(captured)
+    assert len(supporting) == 1
+    entry = supporting[0]
+    assert entry["name"] == "Jane Doe"
+    assert entry["is_organization"] is False
+    assert entry["is_active"] is True  # no end date -> active
+    assert entry["avatar_img"] == "/img/contributors/supporting/jane_doe.png"
+    assert entry["link"] == "https://example.com"
+    assert entry["roles"] == ["Coding", "Translation"]
+    assert entry["contribution_description"] == "Wrote lots of code"
+    assert entry["start_date"] == "2019-01-01"
+    assert entry["end_date"] is None
+
+    # GeoJSON feature mirrors the contributor and carries the coordinates.
+    assert len(geojson["features"]) == 1
+    feature = geojson["features"][0]
+    assert feature["type"] == "Feature"
+    assert feature["geometry"] == {"type": "Point", "coordinates": [12.5, 41.9]}
+    assert feature["properties"]["name"] == "Jane Doe"
+
+
+# ---------------------------------------------------------------------------
+# xlsx_to_supporting_json: filtering, missing image skip, sorting
+# ---------------------------------------------------------------------------
+def test_pipeline_filters_rejects_skips_missing_image_and_sorts(monkeypatch):
+    df = pd.DataFrame(
+        [
+            # Approved, newer start date -> should sort AFTER the 2015 entry.
+            {
+                "Approved (yes/no)": "yes",
+                "Individual or Organisation": "Organisation",
+                "Name": "",
+                "Organization Name": "Beta Org",
+                "Email Address": "beta@example.com",
+                "Type of activities": "Funding",
+                "Description of contribution": "Sponsorship",
+                "Website/Profile link": "",
+                "Location - Longitude": "",
+                "Location - Latitude": "",
+                "Please enter the start date of your activities with the QGIS community": "1/1/20",
+                "Please enter the end date of your activities with the QGIS community": "",
+            },
+            # Approved, older start date -> should sort FIRST.
+            {
+                "Approved (yes/no)": "Yes",
+                "Individual or Organisation": "Individual",
+                "Name": "Alpha Person",
+                "Organization Name": "",
+                "Email Address": "alpha@example.com",
+                "Type of activities": "Coding",
+                "Description of contribution": "Early contributor",
+                "Website/Profile link": "",
+                "Location - Longitude": "",
+                "Location - Latitude": "",
+                "Please enter the start date of your activities with the QGIS community": "1/1/15",
+                "Please enter the end date of your activities with the QGIS community": "",
+            },
+            # Rejected -> excluded from output entirely.
+            {
+                "Approved (yes/no)": "No",
+                "Individual or Organisation": "Individual",
+                "Name": "Rejected Ron",
+                "Organization Name": "",
+                "Email Address": "ron@example.com",
+                "Type of activities": "Coding",
+                "Description of contribution": "Nope",
+                "Website/Profile link": "",
+                "Location - Longitude": "",
+                "Location - Latitude": "",
+                "Please enter the start date of your activities with the QGIS community": "1/1/18",
+                "Please enter the end date of your activities with the QGIS community": "",
+            },
+            # No name -> skipped silently.
+            {
+                "Approved (yes/no)": "Yes",
+                "Individual or Organisation": "Individual",
+                "Name": "",
+                "Organization Name": "",
+                "Email Address": "ghost@example.com",
+                "Type of activities": "Coding",
+                "Description of contribution": "",
+                "Website/Profile link": "",
+                "Location - Longitude": "",
+                "Location - Latitude": "",
+                "Please enter the start date of your activities with the QGIS community": "1/1/10",
+                "Please enter the end date of your activities with the QGIS community": "",
+            },
+        ]
+    )
+    captured = _patch_pipeline(monkeypatch, df, image_exists=True)
+
+    mod.xlsx_to_supporting_json(
+        Path("in.xlsx"),
+        Path("data/contributors/supporting.json"),
+        Path("static/data/contributors/supporting_map.json"),
+    )
+
+    supporting, geojson = _outputs(captured)
+    names = [c["name"] for c in supporting]
+    # Rejected + no-name entries excluded; only the two approved remain.
+    assert names == ["Alpha Person", "Beta Org"]  # sorted by start_date asc
+    # Org name fallback was used and org flag set.
+    beta = supporting[1]
+    assert beta["is_organization"] is True
+    assert beta["start_date"] == "2020-01-01"
+    # No coordinates supplied -> no GeoJSON features.
+    assert geojson["features"] == []
+
+
+# ---------------------------------------------------------------------------
+# xlsx_to_supporting_json: approved entry whose avatar image is missing
+# ---------------------------------------------------------------------------
+def test_pipeline_skips_approved_entry_without_image(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "Approved (yes/no)": "Yes",
+                "Individual or Organisation": "Individual",
+                "Name": "No Image Person",
+                "Organization Name": "",
+                "Email Address": "noimg@example.com",
+                "Type of activities": "Coding",
+                "Description of contribution": "Has no avatar",
+                "Website/Profile link": "",
+                "Location - Longitude": 1.0,
+                "Location - Latitude": 2.0,
+                "Please enter the start date of your activities with the QGIS community": "1/1/22",
+                "Please enter the end date of your activities with the QGIS community": "",
+            }
+        ]
+    )
+    # image_exists=False -> the entry should be skipped, leaving empty output.
+    captured = _patch_pipeline(monkeypatch, df, image_exists=False)
+
+    mod.xlsx_to_supporting_json(
+        Path("in.xlsx"),
+        Path("data/contributors/supporting.json"),
+        Path("static/data/contributors/supporting_map.json"),
+    )
+
+    supporting, geojson = _outputs(captured)
+    assert supporting == []
+    # Even though coordinates were present, the skipped entry adds no feature.
+    assert geojson["features"] == []


### PR DESCRIPTION
### Summary of the Fixes

Follows up on the discussion in #1006: add pytest coverage for the automated scripts so a dependency upgrade that changes their behaviour fails a test, starting with the contributors and donors group.

> **Note — stacked on #1005.** The test harness (`test/conftest.py` and the `python-tests.yml` workflow) lives in #1005. Until that merges, the diff here also shows #1005's commits; it will reduce to just the new test files once #1005 lands. Happy to fold the harness in here instead if that is preferred (open question on #1006).

New tests (network, filesystem, Stripe and Payrexx all mocked; the real parsing / transform / sort logic is exercised):

- `test_update_donors_from_file.py` — name formatting, dedupe, sort, JSON indent.
- `test_update_donors.py` — same plus the mocked Stripe opt-in / opt-out routing in `get_donors`.
- `test_update_payrexx_donors.py` — add/remove/sort, the HMAC signature, and the existing `indent=2` vs `indent=4` write inconsistency is pinned.
- `test_update_individual_contributors.py` — bot filtering, per-thematic aggregation and totals, GraphQL pagination, rate-limit reset parsing, GeoJSON generation (all with `requests` mocked).
- `test_update_supporting_contributors.py` — date parsing, the active-contributor threshold, slugify, and the full XLSX to JSON/GeoJSON pipeline.

`update_supporting_contributors.py` imports `pandas` (and needs `openpyxl` for `read_excel`), which are not in `REQUIREMENTS.txt`, so that test is guarded with `pytest.importorskip("pandas")` and skips in CI until they are added (raised in #1006).