### PR TITLE
fix: add missing title to Security page (#995)

### DIFF
--- a/content/resources/support/security.md
+++ b/content/resources/support/security.md
@@ -11,6 +11,8 @@ Reviewer: Tim Sutton
 
 {{< content-start >}}
 
+# Security
+
 ## Security information
 
 The QGIS community takes security seriously. We are aware that QGIS is deployed in sensitive environments. This page outlines how the QGIS project responds to vulnerabilities and security matters. 


### PR DESCRIPTION
Fixed the missing H1 title on the Security page. The frontmatter had `title: "Security"` for metadata but the page itself lacked the visible `# Security` heading that all other pages in `resources/support/` include.

Closes #995