### PR TITLE
installation-guide: fix Spack info URL

### DIFF
--- a/content/resources/installation-guide/index.md
+++ b/content/resources/installation-guide/index.md
@@ -668,7 +668,7 @@ Spack is a distro agnostic package manager for Linux, which is developed in the 
 
 General info on installing Spack: https://github.com/spack/spack
 
-QGIS package file on Spack: https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/qgis/package.py
+QGIS package info on the Spack website: https://packages.spack.io/package.html?name=qgis
 
 To install:
 


### PR DESCRIPTION
The URL https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/qgis/package.py is currently invalid. The correct one is currently https://github.com/spack/spack-packages/tree/develop/repos/spack_repo/builtin/packages/qgis/package.py
Anyway I think we should remove such link, which could change again in the future, and use the URL of the package info page, instead.