### PR TITLE
Make macOS download links robust to build-upload lag (prevents the recurring #1000 404)

### DIFF
--- a/scripts/macos_dmg.py
+++ b/scripts/macos_dmg.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Resolve macOS .dmg download versions against the actual S3 listing.
+
+The release schedule spreadsheet can name a version whose macOS build has not
+been uploaded to S3 yet, which produces a download link that 404s (issue
+#1000). These helpers look up what is actually present in the generated
+data/downloads/s3_downloads.json listing and pick the newest build that really
+exists for a release series, so the download button always points at a file
+that can be fetched.
+"""
+import re
+
+# e.g. qgis_ltr_final-3_44_10.dmg -> ("3", "44", "10"). Older files carry a
+# build-date suffix (qgis_ltr_final-3_22_10_20220815_145618.dmg), so allow a
+# trailing "_..." after the major_minor_patch part.
+_DMG_RE = re.compile(r"^qgis_(?:ltr|pr)_final-(\d+)_(\d+)_(\d+)(?:_.*)?\.dmg$")
+
+
+def _iter_channel_files(s3_listing, channel):
+    """Yield the file entries under macos/<channel> in the S3 listing tree."""
+    tree = s3_listing.get("tree", {})
+    for macos in tree.get("children", []):
+        if macos.get("name") != "macos":
+            continue
+        for sub in macos.get("children", []):
+            if sub.get("name") == channel:
+                yield from sub.get("files", [])
+
+
+def available_dmg_versions(s3_listing, channel):
+    """Map (major, minor, patch) -> dotted version for every .dmg in a channel.
+
+    channel is "ltr" or "pr" (the macOS subfolders on S3).
+    """
+    versions = {}
+    for entry in _iter_channel_files(s3_listing, channel):
+        match = _DMG_RE.match(entry.get("name", ""))
+        if match:
+            versions[tuple(int(p) for p in match.groups())] = ".".join(match.groups())
+    return versions
+
+
+def latest_available_dmg(requested_version, channel, s3_listing):
+    """Return the dotted version whose .dmg actually exists on S3.
+
+    Prefer the exact requested version; if its build has not been uploaded yet,
+    fall back to the newest patch available in the same major.minor series. If
+    the listing has nothing for that series (or the version cannot be parsed),
+    return the requested version unchanged so behaviour is no worse than before.
+    """
+    try:
+        requested = tuple(int(p) for p in requested_version.split("."))
+    except (AttributeError, ValueError):
+        return requested_version
+
+    available = available_dmg_versions(s3_listing, channel)
+    if requested in available:
+        return requested_version
+
+    same_series = [v for v in available if v[:2] == requested[:2]]
+    if same_series:
+        return available[max(same_series)]
+    return requested_version

--- a/scripts/update-schedule.py
+++ b/scripts/update-schedule.py
@@ -17,6 +17,7 @@ import re
 import codecs
 from datetime import datetime, timedelta, timezone
 from icalendar import Calendar, Event
+from macos_dmg import latest_available_dmg
 
 _DL_BASE = "https://download.qgis.org"
 _TORRENT_BASE = "https://dl1.qgis.org"
@@ -268,6 +269,16 @@ for f in [
 
 ltrversion = ".".join(ltr_version.split(".")[:2])
 
+# The macOS download links must point at .dmg files that actually exist on S3.
+# The schedule can name a version whose macOS build has not been uploaded yet
+# (issue #1000), which 404s the download button, so resolve each version
+# against the generated S3 listing and fall back to the newest patch that is
+# actually available for the series.
+with open("data/downloads/s3_downloads.json") as f:
+    s3_listing = json.load(f)
+ltr_dmg_version = latest_available_dmg(ltr_version, "ltr", s3_listing)
+lr_dmg_version = latest_available_dmg(lr_version, "pr", s3_listing)
+
 with open("data/conf.json", "w") as f:
     json.dump({
         "WARNING": "produced from googlesheet via scripts/update-schedule.py - EDITS WILL BE LOST",
@@ -305,10 +316,10 @@ with open("data/conf.json", "w") as f:
         "ltr_sha": f"https://download.qgis.org/downloads/QGIS-OSGeo4W-{ltr_version}-{ltr_binary}.sha256sum",
         "ltr_grids_msi": f"https://download.qgis.org/downloads/QGIS-Grids-OSGeo4W-{ltr_version}-{ltr_binary}.msi",
         "ltr_grids_sha": f"https://download.qgis.org/downloads/QGIS-Grids-OSGeo4W-{ltr_version}-{ltr_binary}.sha256sum",
-        "ltr_dmg": f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_version)}.dmg",
-        "ltr_dmg_sha": f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_version)}.sha256sum",
-        "lr_dmg": f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_version)}.dmg",
-        "lr_dmg_sha": f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_version)}.sha256sum",
+        "ltr_dmg": f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_dmg_version)}.dmg",
+        "ltr_dmg_sha": f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_dmg_version)}.sha256sum",
+        "lr_dmg": f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_dmg_version)}.dmg",
+        "lr_dmg_sha": f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_dmg_version)}.sha256sum",
         "weekly_msi": "/downloads/windows/weekly/",
 
         # torrent / magnet links (torrent hosted on dl1.qgis.org, magnet from server-generated sidecar)
@@ -324,12 +335,12 @@ with open("data/conf.json", "w") as f:
         "ltr_grids_msi_torrent": torrent_url(f"https://download.qgis.org/downloads/QGIS-Grids-OSGeo4W-{ltr_version}-{ltr_binary}.msi"),
         "ltr_grids_msi_magnet": fetch_magnet(f"https://download.qgis.org/downloads/QGIS-Grids-OSGeo4W-{ltr_version}-{ltr_binary}.msi"),
         "ltr_grids_msi_meta4": meta4_url(f"https://download.qgis.org/downloads/QGIS-Grids-OSGeo4W-{ltr_version}-{ltr_binary}.msi"),
-        "lr_dmg_torrent": torrent_url(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_version)}.dmg"),
-        "lr_dmg_magnet": fetch_magnet(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_version)}.dmg"),
-        "lr_dmg_meta4": meta4_url(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_version)}.dmg"),
-        "ltr_dmg_torrent": torrent_url(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_version)}.dmg"),
-        "ltr_dmg_magnet": fetch_magnet(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_version)}.dmg"),
-        "ltr_dmg_meta4": meta4_url(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_version)}.dmg"),
+        "lr_dmg_torrent": torrent_url(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_dmg_version)}.dmg"),
+        "lr_dmg_magnet": fetch_magnet(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_dmg_version)}.dmg"),
+        "lr_dmg_meta4": meta4_url(f"https://download.qgis.org/downloads/macos/pr/qgis_pr_final-{macos_version(lr_dmg_version)}.dmg"),
+        "ltr_dmg_torrent": torrent_url(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_dmg_version)}.dmg"),
+        "ltr_dmg_magnet": fetch_magnet(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_dmg_version)}.dmg"),
+        "ltr_dmg_meta4": meta4_url(f"https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-{macos_version(ltr_dmg_version)}.dmg"),
     }, f, indent=4)
 
 o = open("content/schedule.ics", "wb")

--- a/test/test_macos_dmg.py
+++ b/test/test_macos_dmg.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for scripts/macos_dmg.py.
+
+update-schedule.py used to build the macOS .dmg download URLs straight from the
+release-schedule version, so when a version was announced before its macOS
+build was uploaded the download button 404'd (issue #1000). latest_available_dmg
+resolves the version against the actual S3 listing instead.
+"""
+import macos_dmg
+
+
+def _listing(channel, names):
+    """Build a minimal s3_downloads.json-shaped tree for one macos channel."""
+    return {
+        "tree": {
+            "children": [
+                {
+                    "name": "macos",
+                    "children": [
+                        {"name": channel, "files": [{"name": n} for n in names]},
+                    ],
+                }
+            ]
+        }
+    }
+
+
+def test_falls_back_to_latest_available_patch_when_exact_missing():
+    listing = _listing("ltr", ["qgis_ltr_final-3_44_9.dmg", "qgis_ltr_final-3_44_10.dmg"])
+    # 3.44.11 announced but not uploaded yet -> use newest available 3.44.10.
+    assert macos_dmg.latest_available_dmg("3.44.11", "ltr", listing) == "3.44.10"
+
+
+def test_returns_exact_version_when_present():
+    listing = _listing("pr", ["qgis_pr_final-4_0_2.dmg", "qgis_pr_final-4_0_3.dmg"])
+    assert macos_dmg.latest_available_dmg("4.0.3", "pr", listing) == "4.0.3"
+
+
+def test_returns_requested_when_series_absent():
+    listing = _listing("ltr", ["qgis_ltr_final-3_40_5.dmg"])
+    # Nothing for the 3.44 series at all -> unchanged (no worse than before).
+    assert macos_dmg.latest_available_dmg("3.44.11", "ltr", listing) == "3.44.11"
+
+
+def test_ignores_non_dmg_and_foreign_prefixes():
+    listing = _listing(
+        "ltr",
+        [
+            "qgis_ltr_final-3_44_10.dmg",
+            "qgis_ltr_final-3_44_11.log",   # not a .dmg
+            "QGIS-final-3_44_12.dmg",       # different prefix -> ignore
+        ],
+    )
+    assert macos_dmg.latest_available_dmg("3.44.11", "ltr", listing) == "3.44.10"
+
+
+def test_handles_date_suffixed_dmg_names():
+    listing = _listing("ltr", ["qgis_ltr_final-3_22_10_20220815_145618.dmg"])
+    assert macos_dmg.latest_available_dmg("3.22.11", "ltr", listing) == "3.22.10"
+
+
+def test_available_dmg_versions_maps_all_dmgs():
+    listing = _listing("pr", ["qgis_pr_final-4_0_3.dmg", "qgis_pr_final-4_0_2.dmg"])
+    assert macos_dmg.available_dmg_versions(listing, "pr") == {
+        (4, 0, 3): "4.0.3",
+        (4, 0, 2): "4.0.2",
+    }
+
+
+def test_unparseable_version_returned_unchanged():
+    listing = _listing("ltr", ["qgis_ltr_final-3_44_10.dmg"])
+    assert macos_dmg.latest_available_dmg("nightly", "ltr", listing) == "nightly"


### PR DESCRIPTION
Addresses the recurring cause of #1000.

## Problem
`scripts/update-schedule.py` builds the macOS `.dmg` download URLs straight from the release-schedule spreadsheet version:

```python
"ltr_dmg": f"...macos/ltr/qgis_ltr_final-{macos_version(ltr_version)}.dmg",
```

When a point release is announced in the schedule *before* its macOS build has been uploaded to S3, that URL points at a file that doesn't exist yet, so the download button returns `AccessDenied`/404. That's exactly what #1000 reported for LTR 3.44.

**Honest note on current state:** this specific instance has since self-resolved — `qgis_ltr_final-3_44_11.dmg` was uploaded (the S3 listing regenerated this morning), so the button works right now. But the gap between "version announced in the sheet" and "macOS build uploaded" recurs every release cycle, so the broken-button condition will come back. This PR fixes that structural fragility rather than a momentary break.

## Fix
Resolve each macOS version against the repo's own generated `data/downloads/s3_downloads.json` listing and use the newest `.dmg` that actually exists for the series:

- exact requested version present (the normal case) → unchanged behaviour;
- present in the sheet but not yet uploaded → fall back to the newest available patch in the same `major.minor` (what @agiudiceandrea suggested in the issue: link the latest available version in the meantime);
- nothing for the series (or an unparseable version) → keep the requested version, so it's never worse than today.

All ten macOS dmg fields (dmg/sha/torrent/magnet/meta4 for both ltr and pr) use the resolved version.

## Why a separate module
The lookup lives in a small importable helper, `scripts/macos_dmg.py`, so it can be unit-tested without executing `update-schedule.py`'s top-level code (it runs network/file work at import). `update-schedule.py` just imports and uses it, keeping that file's change minimal.

## Tests
`test/test_macos_dmg.py` (builds on the pytest harness from #1015) covers the fallback, exact-match, absent-series, non-dmg/foreign-prefix, date-suffixed, and unparseable cases. Full suite green (55 tests). The fallback test uses a mocked listing, so it guards the behaviour regardless of what's currently on S3.