### PR TITLE
Guard match_commercial_contributors.py against ZeroDivisionError on empty data

### DIFF
--- a/scripts/match_commercial_contributors.py
+++ b/scripts/match_commercial_contributors.py
@@ -169,7 +169,10 @@ def save_matches(matches, total_orgs, unmatched_count):
     print(f"   - Active contributors: {active_count}")
     print(f"   - Inactive contributors: {inactive_count}")
     print(f"   Unmatched: {unmatched_count}")
-    print(f"   Match rate: {matched/total_orgs*100:.1f}%")
+    # total_orgs is 0 when the commercial-support data is empty or missing;
+    # report 0% rather than raising ZeroDivisionError.
+    match_rate = (matched / total_orgs * 100) if total_orgs else 0.0
+    print(f"   Match rate: {match_rate:.1f}%")
     
     # Print matched organizations
     if matched > 0:

--- a/test/test_match_commercial_contributors.py
+++ b/test/test_match_commercial_contributors.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for scripts/match_commercial_contributors.py.
+
+save_matches divided by the number of commercial-support orgs to print a match
+rate. When that data is empty or missing the count is 0, so the script crashed
+with ZeroDivisionError instead of reporting 0%.
+"""
+import json
+
+import match_commercial_contributors as mcc
+
+
+def _cd_into_repo_layout(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data" / "commercial_support").mkdir(parents=True)
+
+
+def test_zero_orgs_reports_zero_percent_without_crashing(tmp_path, monkeypatch, capsys):
+    _cd_into_repo_layout(tmp_path, monkeypatch)
+
+    mcc.save_matches({}, 0, 0)  # empty data -> total_orgs == 0
+
+    out = capsys.readouterr().out
+    assert "Match rate: 0.0%" in out
+    saved = json.loads(
+        (tmp_path / "data" / "commercial_support" / "contributor_matches.json").read_text()
+    )
+    assert saved["matches"] == {}
+
+
+def test_match_rate_computed_when_orgs_present(tmp_path, monkeypatch, capsys):
+    _cd_into_repo_layout(tmp_path, monkeypatch)
+
+    matches = {"acme": {"contributor_name": "Acme Ltd", "is_active": True}}
+    mcc.save_matches(matches, 4, 3)  # 1 of 4 matched
+
+    assert "Match rate: 25.0%" in capsys.readouterr().out


### PR DESCRIPTION
Continues the script test-coverage work on top of the harness from #1015.

## Problem
`save_matches` prints a match rate by dividing by the number of commercial-support orgs:

```python
print(f"   Match rate: {matched/total_orgs*100:.1f}%")
```

When the commercial-support data is empty or missing, `total_orgs` is 0, so the scheduled run (invoked from `update-contributors.yml`) crashes with `ZeroDivisionError` instead of reporting a 0% rate.

## Fix
Compute the rate only when there is at least one org, otherwise report 0%:

```python
match_rate = (matched / total_orgs * 100) if total_orgs else 0.0
print(f"   Match rate: {match_rate:.1f}%")
```

## Test
`test/test_match_commercial_contributors.py` covers the empty-data case (no crash, reports 0%, still writes the output file) and a normal rate. Reverting the fix makes the empty-data test fail with the ZeroDivisionError, so it has teeth. Full suite green.