### PR TITLE
Stop the link sanitizer from removing commercial support URLs on transient failures

### DIFF
--- a/scripts/sanitize_commercial_supports.py
+++ b/scripts/sanitize_commercial_supports.py
@@ -6,6 +6,13 @@ from urllib.parse import urlparse
 from requests.exceptions import RequestException
 import os
 
+# Responses that mean "could not verify right now", not "the site is gone":
+# auth walls and bot protection (401/403), HEAD not supported (405), request
+# timeout (408) and rate limiting (429). Together with 5xx server errors they
+# must not empty a URL: emptying is committed to the data files by the weekly
+# workflow and the script never restores a URL on its own.
+TRANSIENT_STATUS_CODES = {401, 403, 405, 408, 429}
+
 def load_yaml(file_path):
     """Load YAML file while preserving formatting"""
     with open(file_path, 'r') as file:
@@ -55,10 +62,13 @@ def check_url_redirects(url):
             verify=True
         )
         
+        if response.status_code in TRANSIENT_STATUS_CODES or response.status_code >= 500:
+            print(f"Keeping URL {url}: temporary or access-restricted response ({response.status_code})")
+            return False
         if response.status_code != 200:
             return True
         redirect_url = response.url
-        
+
         # Handle relative redirects
         if redirect_url.startswith('/'):
             redirect_url = f"{urlparse(url).scheme}://{urlparse(url).netloc}{redirect_url}"
@@ -68,8 +78,11 @@ def check_url_redirects(url):
     except requests.exceptions.SSLError:
         return False
     except RequestException as e:
-        print(f"Error checking URL {url}: {str(e)}")
-        return True
+        # A timeout, DNS hiccup or connection reset says nothing about whether
+        # the link is dead. Keep the URL, like the SSLError case above, instead
+        # of emptying it in the committed data.
+        print(f"Keeping URL {url}: could not verify ({str(e)})")
+        return False
     except Exception as e:
         return False
 

--- a/test/test_sanitize_commercial_supports.py
+++ b/test/test_sanitize_commercial_supports.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for scripts/sanitize_commercial_supports.py.
+
+The weekly sanitize job empties a listing's URL in the committed YAML when the
+link looks broken. It used to treat transient conditions (timeouts, connection
+errors, rate limiting, bot-protection responses) the same as a dead link, so a
+network hiccup during the run removed working URLs from the site permanently:
+the script only ever empties, it never restores.
+"""
+import requests
+
+import sanitize_commercial_supports as san
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, url=None):
+        self.status_code = status_code
+        self.url = url
+
+
+def _patch_head(monkeypatch, outcome):
+    """Make requests.Session().head() return a response or raise an exception."""
+
+    class FakeSession:
+        max_redirects = 5
+
+        def head(self, url, **kwargs):
+            if isinstance(outcome, Exception):
+                raise outcome
+            if outcome.url is None:
+                outcome.url = url
+            return outcome
+
+    monkeypatch.setattr(san.requests, "Session", FakeSession)
+
+
+def test_connection_error_keeps_url(monkeypatch):
+    _patch_head(monkeypatch, requests.exceptions.ConnectionError("reset by peer"))
+    assert san.check_url_redirects("https://example.com/") is False
+
+
+def test_timeout_keeps_url(monkeypatch):
+    _patch_head(monkeypatch, requests.exceptions.ConnectTimeout("timed out"))
+    assert san.check_url_redirects("https://example.com/") is False
+
+
+def test_server_error_keeps_url(monkeypatch):
+    _patch_head(monkeypatch, _FakeResponse(status_code=503))
+    assert san.check_url_redirects("https://example.com/") is False
+
+
+def test_rate_limit_and_bot_protection_keep_url(monkeypatch):
+    for status in (401, 403, 405, 408, 429):
+        _patch_head(monkeypatch, _FakeResponse(status_code=status))
+        assert san.check_url_redirects("https://example.com/") is False, status
+
+
+def test_not_found_empties_url(monkeypatch):
+    _patch_head(monkeypatch, _FakeResponse(status_code=404))
+    assert san.check_url_redirects("https://example.com/") is True
+
+
+def test_cross_domain_redirect_empties_url(monkeypatch):
+    _patch_head(monkeypatch, _FakeResponse(url="https://parked-domain.example/"))
+    assert san.check_url_redirects("https://example.com/") is True
+
+
+def test_same_domain_https_redirect_keeps_url(monkeypatch):
+    _patch_head(monkeypatch, _FakeResponse(url="https://www.example.com/"))
+    assert san.check_url_redirects("http://example.com/") is False
+
+
+def test_blank_url_is_left_alone(monkeypatch):
+    assert san.check_url_redirects("") is False
+    assert san.check_url_redirects("   ") is False
+
+
+def test_process_file_empties_only_flagged_urls(tmp_path, monkeypatch):
+    yml = tmp_path / "others.yml"
+    yml.write_text(
+        "- name: Dead Org\n"
+        '  url: "https://dead.example/"\n'
+        "- name: Live Org\n"
+        '  url: "https://live.example/"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        san, "check_url_redirects", lambda url: url == "https://dead.example/"
+    )
+
+    assert san.process_file(str(yml)) is True
+
+    content = yml.read_text(encoding="utf-8")
+    assert '  url: ""' in content                     # dead one emptied, indent kept
+    assert '  url: "https://live.example/"' in content  # live one untouched
+    assert "- name: Dead Org" in content
+
+
+def test_process_file_leaves_file_untouched_when_all_urls_ok(tmp_path, monkeypatch):
+    yml = tmp_path / "others.yml"
+    original = '- name: Live Org\n  url: "https://live.example/"\n'
+    yml.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(san, "check_url_redirects", lambda url: False)
+
+    assert san.process_file(str(yml)) is False
+    assert yml.read_text(encoding="utf-8") == original


### PR DESCRIPTION
Continues the script reliability and test-coverage work (#1015, #1020, #1042).

## Problem
`scripts/sanitize_commercial_supports.py` runs every Sunday and empties a listing's URL in `data/commercial_support` when the link looks broken; the workflow then commits the result to main. But `check_url_redirects` treated two ambiguous situations as a dead link:

```python
if response.status_code != 200:
    return True            # 403, 429, 503... all counted as dead
...
except RequestException as e:
    return True             # timeout, DNS hiccup, connection reset: also dead
```

Since the script only ever empties URLs and never restores them, every false positive permanently removes a company's link from the site.

## Evidence this is happening
All five URLs emptied by the last three scheduled runs are alive today, and all five pass this script's own check when run locally:

| Emptied in | URL | Status today |
|---|---|---|
| 1cc0f36 (Jun 7) | csgis.de | 200 |
| 1cc0f36 (Jun 7) | envirosolutions.pl | 200 |
| c8910b4 (May 31) | gismexico.com | 200 |
| 6b40174 (May 24) | clearmapping.co.uk | 200 |
| 6b40174 (May 24) | thinkwhere.com | alive (redirect) |

That points at transient conditions on the CI runner: timeouts, rate limiting, or bot protection answering the datacenter IP with 403/429/5xx.

## Fix
Keep the URL whenever the check cannot give a clear verdict, which is the choice the code already makes for `SSLError`:

* network-level exceptions (timeout, DNS, connection reset) keep the URL and log why;
* 5xx server errors and access-restricted or transient statuses (401, 403, 405, 408, 429) keep the URL;
* genuinely broken links (404 and other 4xx) and redirects to a different domain still empty it, unchanged.

## Tests
`test/test_sanitize_commercial_supports.py` (on the #1015 harness, all network mocked): transient exceptions and statuses keep the URL, 404 and cross-domain redirects still empty it, same-domain http to https redirects are fine, and `process_file` empties only flagged lines while preserving formatting. The transient cases fail on the previous code, so the suite has teeth. Full test suite green (60 tests).

Happy to follow up by restoring the five wrongly emptied URLs above in a small data PR if you'd like.