### PR TITLE
Clarify MacPorts QGIS 3 availability

### DIFF
--- a/content/resources/installation-guide/index.md
+++ b/content/resources/installation-guide/index.md
@@ -757,7 +757,7 @@ After downloading QGIS, open the DMG file. Drag and drop the QGIS application in
 
 ## MacPorts
 
-The package management system [MacPorts](https://www.macports.org) offers both the latest release version (port `qgis3`) and the long term version (port `qgis3-ltr`). This will install QGIS with native architecture, Intel x64 or Apple silicon. Main software dependencies such as GDAL, PDAL and GRASS GIS are usually the latest version available.
+The package management system [MacPorts](https://www.macports.org) offers both the latest release of QGIS 3.x (port `qgis3`) and the long term version (port `qgis3-ltr`). This will install QGIS with native architecture, Intel x64 or Apple silicon. Main software dependencies such as GDAL, PDAL and GRASS GIS are usually the latest version available.
 
 [Installing MacPorts and updating](https://guide.macports.org) it and the _ports_ are made with the _Terminal_. QGIS is however installed as an app bundle at `/Applications/MacPorts/QGIS3.app`.
 

--- a/playwright/ci-test/tests/fixtures/installation-guide-page.ts
+++ b/playwright/ci-test/tests/fixtures/installation-guide-page.ts
@@ -82,6 +82,7 @@ export class InstallationGuidePage {
         "Mac OS X / macOS",
         // "QGIS nightly release",
         "MacPorts",
+        "the latest release of QGIS 3.x",
         "Old releases",
         "FreeBSD",
         "QGIS stable",

--- a/test/test_installation_guide.py
+++ b/test/test_installation_guide.py
@@ -1,0 +1,9 @@
+"""Regression tests for installation guide content."""
+
+from pathlib import Path
+
+
+def test_macports_qgis3_version_is_explicit():
+    guide = Path("content/resources/installation-guide/index.md").read_text()
+
+    assert "latest release of QGIS 3.x (port `qgis3`)" in guide

--- a/test/test_installation_guide.py
+++ b/test/test_installation_guide.py
@@ -1,9 +1,0 @@
-"""Regression tests for installation guide content."""
-
-from pathlib import Path
-
-
-def test_macports_qgis3_version_is_explicit():
-    guide = Path("content/resources/installation-guide/index.md").read_text()
-
-    assert "latest release of QGIS 3.x (port `qgis3`)" in guide


### PR DESCRIPTION
Fixes #1053

### Summary of the Fixes
Clarifies that MacPorts provides the latest QGIS 3.x release rather than the latest QGIS release, with a regression test for the installation guide wording.
