### PR TITLE
Update announcement details and fix theme submodule reference

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -17,10 +17,8 @@ OsgeoBadge: "img/badges/osgeo-logo-white.svg"
 OsgeoBadgeLink: "https://www.osgeo.org/projects/qgis/"
 
 HasAnnouncement: true
-AnnouncementLabel: "QGIS 4.0"
-AnnouncementTitle: "QGIS 4.0 is here — our most powerful release yet!"
+AnnouncementTitle: "is here!"
 AnnouncementText: "Discover the new features, improvements, and everything that makes this release a landmark moment."
-AnnouncementLink: "project/visual-changelogs/visualchangelog40/"
 AnnouncementLinkText: "Explore the changelog"
 ---
 

--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,17 @@
     "qgis-website-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1781193698,
-        "narHash": "sha256-3pptYX3BV0Nm115bsbLQUnz4HAIERWeptAvG9vke3o8=",
+        "lastModified": 1784711285,
+        "narHash": "sha256-sCKKh0rWh2dt24B1M+FI8JBnY6LKk6gBvfuvXbqy2HU=",
         "owner": "qgis",
         "repo": "QGIS-Hugo-Website-Theme",
-        "rev": "6843fab4f86d306e2eedd7b66b4ef48706fcfe8c",
+        "rev": "f42ab6a8dcd363282d978275c7c2bc06a33c89cc",
         "type": "github"
       },
       "original": {
         "owner": "qgis",
         "repo": "QGIS-Hugo-Website-Theme",
+        "rev": "f42ab6a8dcd363282d978275c7c2bc06a33c89cc",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
 
     # Fetch the Hugo theme submodule directly as a flake input
     qgis-website-theme = {
-      url = "github:qgis/QGIS-Hugo-Website-Theme";
+      url = "github:qgis/QGIS-Hugo-Website-Theme/f42ab6a8dcd363282d978275c7c2bc06a33c89cc";
       flake = false; # it's not a flake, just a source tree
     };
   };


### PR DESCRIPTION
Closes #1061

The version announcement in the announcement banner is now based on the current released version

Depends on https://github.com/qgis/QGIS-Hugo-Website-Theme/pull/20

<img width="1640" height="91" alt="image" src="https://github.com/user-attachments/assets/f54619b4-765c-4f9f-b19d-54344637cfd3" />

