### PR TITLE
Rename QGIS UC 2025 to QGIS User Conference in sidebar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -358,11 +358,11 @@ sectionPagesMenu = 'main'
 
 [[menu.main]]
   parent = "Meetings"
-  name = "QGIS Conference"
+  name = "QGIS User Conference"
   url = "https://conference.qgis.org/"
   weight = 185
   [menu.main.params]
-    i18n_key = "menuQGISUC2025"
+    i18n_key = "menuQGISUC"
 
 
 [[menu.main]]

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -364,8 +364,8 @@
   translation: "Mailing Lists"
 
 # Meetings submenu
-- id: menuQGISUC2025
-  translation: "QGIS UC 2025"
+- id: menuQGISUC
+  translation: "QGIS User Conference"
 - id: menuQGISUserMeetings
   translation: "QGIS User Meetings"
 - id: menuQGISDeveloperMeetings


### PR DESCRIPTION
Closes #1060

<img width="1661" height="811" alt="image" src="https://github.com/user-attachments/assets/2650b3fd-cf7e-4465-b176-8c06184db980" />
