### PR TITLE
Normalise scheme-less member URLs in fetch_feeds.py

### DIFF
--- a/fetch_feeds.py
+++ b/fetch_feeds.py
@@ -19,6 +19,18 @@ from scripts.resize_image import resize_image
 # (connect, read) timeouts in seconds so a hung host can't stall the job.
 REQUEST_TIMEOUT = (10, 300)
 
+
+def ensure_scheme(url):
+    """Prefix scheme-less URLs like "www.example.com" with https://.
+
+    The members feed carries some member URLs without a scheme; written as-is
+    into the generated funders pages they render as relative links and 404.
+    """
+    if url and not url.startswith(("http://", "https://")):
+        return f"https://{url}"
+    return url
+
+
 ### Funders
 def fetch_funders(url: str):
     """
@@ -35,7 +47,7 @@ def fetch_funders(url: str):
     for item in items:
         member_slug = item["slug"]
         markdown_filename = f"content/funders/{member_slug}.md"
-        link = item["member_url"]
+        link = ensure_scheme(item["member_url"])
         image_url = item["image_url"]
         title = item["title"]
         level = item["member_level"]

--- a/test/test_fetch_feeds.py
+++ b/test/test_fetch_feeds.py
@@ -73,3 +73,22 @@ def test_multiple_members_list_still_works(tmp_path, monkeypatch):
     funders = tmp_path / "content" / "funders"
     assert (funders / "acme.md").is_file()
     assert (funders / "globex.md").is_file()
+
+
+def test_scheme_less_member_url_is_normalised(tmp_path, monkeypatch):
+    # A member URL without a scheme used to be written as-is into the funders
+    # page, where it rendered as a relative link and returned 404.
+    member = _member("bgeo")
+    member["member_url"] = "www.bgeo.es"
+    _install_fakes(tmp_path, monkeypatch, member)
+
+    fetch_feeds.fetch_funders("https://members.example/json/")
+
+    md = (tmp_path / "content" / "funders" / "bgeo.md").read_text(encoding="utf-8")
+    assert 'link: "https://www.bgeo.es"' in md
+
+
+def test_ensure_scheme_leaves_proper_urls_alone():
+    assert fetch_feeds.ensure_scheme("https://example.com/") == "https://example.com/"
+    assert fetch_feeds.ensure_scheme("http://example.com") == "http://example.com"
+    assert fetch_feeds.ensure_scheme("") == ""


### PR DESCRIPTION
Follows up on the #1054 review, where @Xpirix confirmed this is worth fixing in `fetch_feeds.py`.

The members feed carries some member URLs without a scheme; `content/funders/bgeo-open-gis-sl.md` currently has `link: "www.bgeo.es"`. Written as-is into the generated funders pages, these render as relative links (for example `https://qgis.org/funding/membership/members/www.bgeo.es`) and 404 wherever the funders strip appears.

The fix prefixes `https://` when the scheme is missing and leaves proper URLs untouched, with tests for both (on the suite from #1015/#1021). The generated file will correct itself on the next scheduled feeds run, after which the `/www\.` exclusion in the link check workflow can be dropped.