### PR TITLE
Drop the www exclusion from the site link check

### DIFF
--- a/.github/workflows/check-site-links.yml
+++ b/.github/workflows/check-site-links.yml
@@ -54,8 +54,6 @@ jobs:
           #   the harvester, after which this exclusion can be dropped
           # - /project/images/: case-study thumbnails on the project page,
           #   rendered by the theme shortcode with a known wrong relative path
-          # - /www.: scheme-less URL in the generated funders content, to be
-          #   fixed in fetch_feeds.py
           args: >-
             --offline
             --no-progress
@@ -64,5 +62,4 @@ jobs:
             --exclude '/downloads(/|$)'
             --exclude 'visual-changelogs/[^/]+/images/entries/'
             --exclude '/project/images/'
-            --exclude '/www\.'
             'public/**/*.html'


### PR DESCRIPTION
Follow-up promised on #1054: with #1070 merged, the nightly feeds run has regenerated `content/funders/bgeo-open-gis-sl.md` with a proper `https://` URL, so the temporary `/www\.` exclusion in `check-site-links.yml` is no longer needed. One line removed plus its comment.

Verified locally against current main: 56,331 links checked, 0 errors without the exclusion.