### PR TITLE
Add explicit explanation for binary availability in roadmap

### DIFF
--- a/content/resources/roadmap.md
+++ b/content/resources/roadmap.md
@@ -10,6 +10,20 @@ sidebar: true
 
 # Road Map
 
+{{< rich-box-start id="binary-availability" >}}
+
+{{< rich-content-start themeClass="coloring-2" >}}
+
+#### About these dates and binary availability
+
+The dates below are **source code** release dates. Binary installers are built by the platform maintainers and normally follow soon after, usually within a few days.
+
+Currently available binaries: **LTR {{< param "ltrrelease" >}}** and **Latest {{< param "release" >}}**. Please see the [download page]({{< ref "download" >}}) do get them.
+
+{{< rich-content-end >}}
+
+{{< rich-box-end >}}
+
 {{< roadmap >}}
 
 {{< button

--- a/content/resources/roadmap.md
+++ b/content/resources/roadmap.md
@@ -18,7 +18,7 @@ sidebar: true
 
 The dates below are **source code** release dates. Binary installers are built by the platform maintainers and normally follow soon after, usually within a few days.
 
-Currently available binaries: **LTR {{< param "ltrrelease" >}}** and **Latest {{< param "release" >}}**. Please see the [download page]({{< ref "download" >}}) do get them.
+Currently available binaries: **LTR {{< param "ltrrelease" >}}** and **Latest {{< param "release" >}}**. Please see the [download page]({{< ref "download" >}}).
 
 {{< rich-content-end >}}
 


### PR DESCRIPTION
Closes #1047

<img width="1545" height="863" alt="image" src="https://github.com/user-attachments/assets/eaa0f830-7a37-4b84-8849-f3941c02ad5c" />

