### PR TITLE
Add OSGeo inject badge

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -13,8 +13,6 @@ SupportedOS: "Available on Windows, Mac, Linux"
 LabelText: "Free and Open Source"
 Badge: "img/badges/dpg-badge.png"
 BadgeLink: "https://blog.qgis.org/2025/02/08/qgis-recognized-as-digital-public-good/"
-OsgeoBadge: "img/badges/osgeo-logo-white.svg"
-OsgeoBadgeLink: "https://www.osgeo.org/projects/qgis/"
 
 HasAnnouncement: true
 AnnouncementTitle: "is here!"


### PR DESCRIPTION
Cc @timlinux 

This will add the OSGeo Badge from https://github.com/timlinux/osgeo-inject to the Homepage. Since there is no production CDN yet, I have included the static files to the changes here.

Depends on https://github.com/qgis/QGIS-Hugo-Website-Theme/pull/24

## Desktop collapsed

<img width="2456" height="1397" alt="image" src="https://github.com/user-attachments/assets/b5fe301d-982b-4bc7-aed6-c50b9d92e8c4" />

## Mobile collapsed

<img width="497" height="1088" alt="image" src="https://github.com/user-attachments/assets/f1ae1023-19fe-4871-96df-24058155305c" />


## Desktop expanded

<img width="2458" height="1397" alt="image" src="https://github.com/user-attachments/assets/28140b2f-ad0f-4b3e-ab3c-a93162bb88ec" />

## Mobile expanded

<img width="498" height="1083" alt="image" src="https://github.com/user-attachments/assets/f43823cc-24af-422f-8bd4-61f2866ea626" />

AI statement: AI was involved to help in this PR
