### PR TITLE
fix: use "Linux" heading in installation guide sidebar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -589,7 +589,7 @@ sectionPagesMenu = 'main'
     url = "/resources/installation-guide/#linux"
     weight = 50
     [menu.main.params]
-      i18n_key = "menuDebianUbuntu"
+      i18n_key = "menuLinux"
 
 
   [[menu.main]]


### PR DESCRIPTION
Currently, all the distro-specific linux installation instructions are grouped under "Debian / Ubuntu". This changes the sidebar to use the more fitting "Linux" header.

Before:
<img width="259" height="331" alt="image" src="https://github.com/user-attachments/assets/5139aa5a-54ad-4ae2-b026-344935526913" />

After:
<img width="263" height="335" alt="image" src="https://github.com/user-attachments/assets/e89b36c6-045d-4e66-83f1-b34519658e69" />
