### PR TITLE
Stop optimize_changelogs.py from deleting webp-named images

### DIFF
--- a/scripts/optimize_changelogs.py
+++ b/scripts/optimize_changelogs.py
@@ -109,19 +109,38 @@ class ChangelogOptimizer:
             elif img.mode != 'RGB':
                 img = img.convert('RGB')
             
-            # Save as webp
+            # Save as webp. For a file whose name already ends in .webp
+            # (including the harvester's name.png.webp convention) the target
+            # name equals the source name, so the image is optimized in place
+            # and there is nothing to delete. Deleting unconditionally used to
+            # destroy exactly those files: the optimized copy was written over
+            # the original and then unlinked, while index.md kept referencing
+            # it.
             new_filename = image_path.stem + '.webp'
             new_path = image_path.parent / new_filename
-            img.save(new_path, 'WEBP', quality=self.quality, method=6)
-            
-            # Delete original
+
+            # Write atomically so a failed save cannot leave a truncated or
+            # missing image behind.
+            tmp_path = new_path.with_name(new_path.name + '.tmp')
+            img.save(tmp_path, 'WEBP', quality=self.quality, method=6)
+            os.replace(tmp_path, new_path)
+
+            if new_path == image_path:
+                print(f"  Optimized in place: {image_path.name} ({size_info})")
+                return None
+
+            # Delete the original only now that the replacement exists.
             image_path.unlink()
-            
+
             print(f"  Optimized: {image_path.name} → {new_filename} ({size_info})")
             return new_filename
-            
+
         except Exception as e:
             print(f"  Error processing {image_path.name}: {e}")
+            # Remove a partially written temporary file if the save failed.
+            tmp_path = image_path.parent / (image_path.stem + '.webp.tmp')
+            if tmp_path.exists():
+                tmp_path.unlink()
             return None
     
     def optimize_images(self):
@@ -172,21 +191,46 @@ class ChangelogOptimizer:
         
         print(f"✓ Updated index.md")
     
+    def verify_references(self):
+        """Check that every image referenced by index.md exists on disk.
+
+        Returns the sorted list of missing filenames. A silent mismatch here
+        is how gallery images can disappear while index.md keeps pointing at
+        them, so callers should treat a non-empty result as a failure.
+        """
+        missing = sorted(
+            name for name in self.get_referenced_images()
+            if not (self.entries_dir / name).exists()
+        )
+        for name in missing:
+            print(f"  Missing referenced image: images/entries/{name}")
+        return missing
+
     def process(self):
-        """Run all optimization tasks"""
+        """Run all optimization tasks; return the number of broken references"""
         print(f"\n{'='*60}")
         print(f"Processing: {self.changelog_dir.name}")
         print(f"{'='*60}\n")
-        
+
         # Step 1: Optimize images
         print("Step 1: Optimizing images")
         conversions = self.optimize_images()
-        
+
         # Step 2: Update index.md
         print("\nStep 2: Updating index.md")
         self.update_index_md(conversions)
-        
+
+        # Step 3: Fail loud when a referenced image is missing, instead of
+        # leaving broken references behind silently.
+        print("\nStep 3: Verifying image references")
+        missing = self.verify_references()
+        if missing:
+            print(f"✗ {self.changelog_dir.name}: {len(missing)} referenced image(s) missing")
+        else:
+            print("✓ All referenced images exist")
+
         print(f"\n✓ Completed processing: {self.changelog_dir.name}\n")
+        return len(missing)
 
 
 def main():
@@ -207,18 +251,25 @@ def main():
             return
         
         optimizer = ChangelogOptimizer(changelog_dir)
-        optimizer.process()
+        missing = optimizer.process()
+        if missing:
+            sys.exit(f"{changelog_name}: {missing} referenced image(s) missing")
     else:
         # Process all changelogs
         changelog_dirs = sorted([d for d in changelogs_base.iterdir() if d.is_dir()])
-        
+
         print(f"\nFound {len(changelog_dirs)} changelogs to process\n")
-        
+
+        total_missing = 0
         for changelog_dir in changelog_dirs:
             optimizer = ChangelogOptimizer(changelog_dir)
-            optimizer.process()
-        
+            total_missing += optimizer.process()
+
         print(f"\n{'='*60}")
+        if total_missing:
+            print(f"✗ Done, but {total_missing} referenced image(s) are missing (see above)")
+            print(f"{'='*60}\n")
+            sys.exit(1)
         print("✓ All changelogs processed successfully!")
         print(f"{'='*60}\n")
 

--- a/test/test_optimize_changelogs.py
+++ b/test/test_optimize_changelogs.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for scripts/optimize_changelogs.py.
+
+For an image whose name already ends in .webp (including the harvester's
+name.png.webp convention), the optimizer's target filename equals the source
+filename. It used to write the optimized copy over the original and then
+unconditionally delete that same path, destroying the file while index.md kept
+referencing it; that is how 24 of the 30 gallery images vanished from
+visualchangelog342.
+"""
+import pytest
+
+pytest.importorskip("PIL")
+from PIL import Image
+
+from optimize_changelogs import ChangelogOptimizer
+
+
+def _make_changelog(tmp_path, images, index_lines):
+    """Build a minimal changelog dir with oversized images and an index.md."""
+    entries = tmp_path / "images" / "entries"
+    entries.mkdir(parents=True)
+    for name in images:
+        fmt = "GIF" if name.endswith(".gif") else ("WEBP" if name.endswith(".webp") else "PNG")
+        # 1500x900 exceeds the 1200x800 limits, so every image needs a rescale.
+        Image.new("RGB", (1500, 900), (10, 120, 200)).save(entries / name, fmt)
+    (tmp_path / "index.md").write_text(
+        "\n".join(f"![shot](images/entries/{name})" for name in index_lines) + "\n",
+        encoding="utf-8",
+    )
+    return ChangelogOptimizer(tmp_path), entries
+
+
+def test_webp_named_image_survives_optimization(tmp_path):
+    # foo.png.webp: stem is "foo.png", so the target name equals the source
+    # name. The file must be optimized in place, not deleted.
+    optimizer, entries = _make_changelog(
+        tmp_path, ["foo.png.webp"], ["foo.png.webp"]
+    )
+
+    missing = optimizer.process()
+
+    assert (entries / "foo.png.webp").exists()
+    assert missing == 0
+    index = (tmp_path / "index.md").read_text(encoding="utf-8")
+    assert "images/entries/foo.png.webp" in index
+
+
+def test_png_is_converted_and_reference_updated(tmp_path):
+    optimizer, entries = _make_changelog(tmp_path, ["bar.png"], ["bar.png"])
+
+    missing = optimizer.process()
+
+    assert (entries / "bar.webp").exists()
+    assert not (entries / "bar.png").exists()
+    assert missing == 0
+    index = (tmp_path / "index.md").read_text(encoding="utf-8")
+    assert "images/entries/bar.webp" in index
+    assert "images/entries/bar.png)" not in index
+
+
+def test_small_image_is_left_alone(tmp_path):
+    optimizer, entries = _make_changelog(tmp_path, [], [])
+    small = entries / "small.png"
+    Image.new("RGB", (400, 300), (200, 30, 30)).save(small, "PNG")
+    (tmp_path / "index.md").write_text(
+        "![shot](images/entries/small.png)\n", encoding="utf-8"
+    )
+
+    missing = optimizer.process()
+
+    assert small.exists()
+    assert missing == 0
+
+
+def test_missing_reference_is_reported(tmp_path):
+    # index.md points at an image that does not exist: process() must report
+    # it instead of finishing silently.
+    optimizer, _ = _make_changelog(tmp_path, [], ["ghost.webp"])
+
+    assert optimizer.process() == 1
+
+
+def test_no_stray_tmp_files_left_behind(tmp_path):
+    optimizer, entries = _make_changelog(
+        tmp_path, ["a.png", "b.png.webp"], ["a.png", "b.png.webp"]
+    )
+
+    optimizer.process()
+
+    assert not list(entries.glob("*.tmp"))


### PR DESCRIPTION
Root cause of the missing changelog gallery images discussed on #1054. You restored the 3.42 data in 53b0cfc, @Xpirix; this fixes the script that destroyed it, so it cannot happen again on the next run.

## What happened
`optimize_image` computes the target name with `Path.stem + '.webp'`. `stem` strips only the last suffix, so for a file whose name already ends in `.webp` (including the harvester's `name.png.webp` convention from `resize_image.py`) the target equals the source:

| input | stem | target |
|---|---|---|
| `0ac30205....png.webp` | `0ac30205....png` | `0ac30205....png.webp` (same file) |
| `17dd1dee....webp` | `17dd1dee...` | `17dd1dee....webp` (same file) |
| `copy_paste_widget.png` | `copy_paste_widget` | `copy_paste_widget.webp` (fine) |

The script then saved the optimized copy over the original and unconditionally ran `image_path.unlink()`, deleting the file it had just written. `update_index_md` did an identity replace, so the reference survived and nothing warned. Commit b967ad143 shows the result for changelog 3.42: 24 image deletions with no matching additions, while `index.md` kept pointing at all of them. Only oversized images were affected because small non-gif files return early, which is why some changelogs escaped.

## Fix
* When the target name equals the source name, optimize in place and delete nothing.
* Write atomically (temp file then `os.replace`), so a failed save cannot leave a truncated or missing image; stray temp files are cleaned up on error.
* After processing, verify every image referenced by `index.md` exists on disk and exit non-zero listing the missing ones, instead of finishing silently. Note this also means the script will now flag the pre-existing missing `thumbnails/` references in the oldest changelogs (3.0 through 2.18) if run across everything, which looks like a separate, older issue worth its own look.

## Tests
`test/test_optimize_changelogs.py` on the existing pytest harness (Pillow is already in REQUIREMENTS.txt): the webp-named survival case fails on the previous code, plus normal png conversion with reference update, small images untouched, missing-reference reporting, and no leftover temp files. Full suite green (71 tests).