### PR TITLE
Run Transifex coverage workflow only in qgis repo

### DIFF
--- a/.github/workflows/tx-coverage.yml
+++ b/.github/workflows/tx-coverage.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   fetch-coverage:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'qgis'
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
This helps avoid this daily noise: https://github.com/DelazJ/QGIS-Website/actions/workflows/tx-coverage.yml